### PR TITLE
Returns Owned Binding for Clone methods

### DIFF
--- a/doxybindgen.toml
+++ b/doxybindgen.toml
@@ -38,6 +38,10 @@ cxx = "#if wxCHECK_VERSION(3, 1, 0)"
 blocklist = [
     'operator delete',
 ]
+[types.wxEvent]
+returns_owned = [
+    'Clone',
+]
 [types.wxEvtHandler]
 blocklist = [
     'Bind1',
@@ -184,4 +188,8 @@ blocklist = [
     'operator*=',
     # Didn't support
     'Scale',
+]
+[types.wxValidator]
+returns_owned = [
+    'Clone',
 ]

--- a/doxybindgen/binding.py
+++ b/doxybindgen/binding.py
@@ -244,7 +244,7 @@ class RustMethodBinding:
                     self.__model.returns.is_ptr_to_binding()):
                     if self.is_ctor:
                         returns = '%sIsOwned<OWNED>' % (returns,)
-                    else:
+                    elif not self.__model.returns_owned():
                         returns = 'WeakRef<%s>' % (returns,)
                 if self.__model.returns.is_str():
                     returns = 'String'
@@ -394,6 +394,8 @@ class RustMethodBinding:
             return '%sIsOwned(%s)' % (wrapped[2:], call)
         wrapped = self.__model.wrapped_return_type(allows_ptr=True)
         if wrapped:
+            if self.__model.returns_owned():
+                return '%s::from_ptr(%s)' % (wrapped[2:], call)
             return 'WeakRef::<%s>::from(%s)' % (wrapped[2:], call)
         return call
 

--- a/doxybindgen/model.py
+++ b/doxybindgen/model.py
@@ -153,6 +153,10 @@ class Method:
         if self.returns.needs_new():
             return True
         return False
+    
+    def returns_owned(self):
+        returns_owned_list = self.cls.config.get('returns_owned') or []
+        return self.name() in returns_owned_list
 
     def cxx_signature(self):
         items = []

--- a/wx-base/src/generated.rs
+++ b/wx-base/src/generated.rs
@@ -144,8 +144,8 @@ pub mod methods {
 
     // wxEvent
     pub trait EventMethods: ObjectMethods {
-        fn clone(&self) -> WeakRef<Event> {
-            unsafe { WeakRef::<Event>::from(ffi::wxEvent_Clone(self.as_ptr())) }
+        fn clone(&self) -> Event {
+            unsafe { Event::from_ptr(ffi::wxEvent_Clone(self.as_ptr())) }
         }
         fn get_event_object(&self) -> WeakRef<Object> {
             unsafe { WeakRef::<Object>::from(ffi::wxEvent_GetEventObject(self.as_ptr())) }

--- a/wx-core/src/generated.rs
+++ b/wx-core/src/generated.rs
@@ -3409,8 +3409,8 @@ pub mod methods {
     // wxValidator
     pub trait ValidatorMethods: EvtHandlerMethods {
         // DTOR: fn ~wxValidator()
-        fn clone(&self) -> WeakRef<Object> {
-            unsafe { WeakRef::<Object>::from(ffi::wxValidator_Clone(self.as_ptr())) }
+        fn clone(&self) -> Object {
+            unsafe { Object::from_ptr(ffi::wxValidator_Clone(self.as_ptr())) }
         }
         fn get_window(&self) -> WeakRef<Window> {
             unsafe { WeakRef::<Window>::from(ffi::wxValidator_GetWindow(self.as_ptr())) }


### PR DESCRIPTION
fixes https://github.com/kenz-gelsoft/wxRust2/issues/58

I've marked these Clone methods by searching clone, ownership or copy in documentation.

If I've missed something, they're leaks, but it's better than double free.