### PR TITLE
Widgets sample: (Generic)DirCtrl page 

### DIFF
--- a/codegen2.py
+++ b/codegen2.py
@@ -148,6 +148,7 @@ def generated_h(classes, libname):
 #include <wx/dirctrl.h>
 #include <wx/filepicker.h>
 #include <wx/wrapsizer.h>
+#include <wx/wupdlock.h>
 
 // wxBitmapBundle compatibility hack(for a while)
 #if !wxCHECK_VERSION(3, 1, 6)

--- a/codegen2.py
+++ b/codegen2.py
@@ -145,6 +145,7 @@ def generated_h(classes, libname):
 #include <wx/bookctrl.h>
 #include <wx/clrpicker.h>
 #include <wx/datectrl.h>
+#include <wx/dirctrl.h>
 #include <wx/filepicker.h>
 #include <wx/wrapsizer.h>
 

--- a/codegen2.py
+++ b/codegen2.py
@@ -157,6 +157,7 @@ typedef wxBitmap wxBitmapBundle;
     else:
         yield '''\
 #include <wx/filename.h>
+#include <wx/stdpaths.h>
 
 typedef wxDateTime::TimeZone TimeZone;
 typedef wxDateTime::Tm       Tm;

--- a/codegen2.py
+++ b/codegen2.py
@@ -148,7 +148,6 @@ def generated_h(classes, libname):
 #include <wx/dirctrl.h>
 #include <wx/filepicker.h>
 #include <wx/wrapsizer.h>
-#include <wx/wupdlock.h>
 
 // wxBitmapBundle compatibility hack(for a while)
 #if !wxCHECK_VERSION(3, 1, 6)

--- a/doxybindgen.toml
+++ b/doxybindgen.toml
@@ -71,6 +71,9 @@ cxx = "#ifndef __WXMSW__"
 [conditions.mac]
 cxx = "#ifdef __WXOSX__"
 
+[conditions.gtk]
+cxx = "#ifdef __WXGTK__"
+
 [conditions.not_gtk]
 cxx = "#ifndef __WXGTK__"
 
@@ -480,6 +483,10 @@ windows = [
     'IgnoreAppSubDir',
     'IgnoreAppBuildSubDirs',
     'MSWGetShellDir',
+]
+gtk = [
+    'GetInstallPrefix',
+    'SetInstallPrefix',
 ]
 [types.wxStaticBox]
 blocklist = [

--- a/doxybindgen.toml
+++ b/doxybindgen.toml
@@ -56,6 +56,7 @@ wxml_files = [
     'wxml/classwx_top_level_window.xml',
     'wxml/classwx_validator.xml',
     'wxml/classwx_window.xml',
+    'wxml/classwx_window_update_locker.xml',
     'wxml/classwx_wrap_sizer.xml',
 ]
 
@@ -593,3 +594,5 @@ wx31 = [
     'UseBackgroundColour',
     'UseForegroundColour',
 ]
+[types.wxWindowUpdateLocker]
+library = 'core'

--- a/doxybindgen.toml
+++ b/doxybindgen.toml
@@ -24,6 +24,7 @@ wxml_files = [
     'wxml/classwx_file_name.xml',
     'wxml/classwx_frame.xml',
     'wxml/classwx_g_d_i_object.xml',
+    'wxml/classwx_generic_dir_ctrl.xml',
     'wxml/classwx_icon.xml',
     'wxml/classwx_item_container.xml',
     'wxml/classwx_item_container_immutable.xml',

--- a/doxybindgen.toml
+++ b/doxybindgen.toml
@@ -44,6 +44,7 @@ wxml_files = [
     'wxml/classwx_size.xml',
     'wxml/classwx_sizer.xml',
     'wxml/classwx_sizer_flags.xml',
+    'wxml/classwx_standard_paths.xml',
     'wxml/classwx_static_bitmap.xml',
     'wxml/classwx_static_box.xml',
     'wxml/classwx_static_box_sizer.xml',
@@ -471,6 +472,13 @@ wx31 = [
     'CentreHorizontal',
     'CentreVertical',
     'DisableConsistencyChecks',
+]
+[types.wxStandardPaths]
+windows = [
+    'DontIgnoreAppSubDir',
+    'IgnoreAppSubDir',
+    'IgnoreAppBuildSubDirs',
+    'MSWGetShellDir',
 ]
 [types.wxStaticBox]
 blocklist = [

--- a/doxybindgen.toml
+++ b/doxybindgen.toml
@@ -56,7 +56,6 @@ wxml_files = [
     'wxml/classwx_top_level_window.xml',
     'wxml/classwx_validator.xml',
     'wxml/classwx_window.xml',
-    'wxml/classwx_window_update_locker.xml',
     'wxml/classwx_wrap_sizer.xml',
 ]
 
@@ -601,5 +600,3 @@ wx31 = [
     'UseBackgroundColour',
     'UseForegroundColour',
 ]
-[types.wxWindowUpdateLocker]
-library = 'core'

--- a/doxybindgen/model.py
+++ b/doxybindgen/model.py
@@ -214,7 +214,8 @@ class Method:
         return is_trackable
     
     def maybe_returns_self(self):
-        return self.returns.is_self_ref(self.cls.name)
+        return (self.returns.is_self_ref(self.cls.name) and
+                not self.is_static)
 
     def cxx_signature(self):
         items = []

--- a/samples/widgets/src/dirctrl.rs
+++ b/samples/widgets/src/dirctrl.rs
@@ -79,14 +79,21 @@ impl From<StdPath> for c_int {
 
 #[derive(Clone)]
 pub struct ConfigUI {
-    // other controls
-// --------------
-// chk_dir_text_ctrl: wx::CheckBox,
-// chk_dir_change_dir: wx::CheckBox,
-// chk_dir_must_exist: wx::CheckBox,
-// chk_small: wx::CheckBox,
-// // text_initial_dir: wx::TextCtrl,
-// sizer: wx::BoxSizer,
+    // the text entries for command parameters
+    path: wx::TextCtrl,
+
+    radio_std_path: wx::RadioBox,
+
+    // flags
+    chk_dir_only: wx::CheckBox,
+    chk_3d: wx::CheckBox,
+    chk_first: wx::CheckBox,
+    chk_filters: wx::CheckBox,
+    chk_labels: wx::CheckBox,
+    chk_multi: wx::CheckBox,
+
+    // filters
+    fltr: [wx::CheckBox; 3],
 }
 
 #[derive(Clone)]
@@ -165,7 +172,7 @@ impl WidgetsPage for DirCtrlWidgetsPage {
 
         let sizer_filters =
             wx::StaticBoxSizer::new_with_int(wx::VERTICAL, Some(&self.base), "&Filters");
-        let filters = [
+        let fltr = [
             self.create_check_box_and_add_to_sizer(
                 &sizer_filters,
                 &format!(
@@ -260,12 +267,15 @@ impl WidgetsPage for DirCtrlWidgetsPage {
 
         // final initializations
         let config_ui = ConfigUI {
-            // chk_dir_text_ctrl,
-            // chk_dir_change_dir,
-            // chk_dir_must_exist,
-            // chk_small,
-            // // text_initial_dir,
-            // sizer,
+            path,
+            radio_std_path,
+            chk_dir_only,
+            chk_3d,
+            chk_first,
+            chk_filters,
+            chk_labels,
+            chk_multi,
+            fltr,
         };
         self.reset(&config_ui);
         *self.config_ui.borrow_mut() = Some(config_ui);
@@ -324,18 +334,22 @@ impl DirCtrlWidgetsPage {
     }
 
     fn reset(&self, config_ui: &ConfigUI) {
-        // config_ui
-        //     .chk_dir_text_ctrl
-        //     .set_value((wx::DIRP_DEFAULT_STYLE & wx::DIRP_USE_TEXTCTRL) != 0);
-        // config_ui
-        //     .chk_dir_must_exist
-        //     .set_value((wx::DIRP_DEFAULT_STYLE & wx::DIRP_DIR_MUST_EXIST) != 0);
-        // config_ui
-        //     .chk_dir_change_dir
-        //     .set_value((wx::DIRP_DEFAULT_STYLE & wx::DIRP_CHANGE_DIR) != 0);
-        // config_ui
-        //     .chk_small
-        //     .set_value((wx::FLP_DEFAULT_STYLE & wx::DIRP_SMALL) != 0);
+        config_ui.path.clear();
+
+        config_ui.chk_dir_only.set_value(false);
+        config_ui.chk_3d.set_value(false);
+        config_ui.chk_first.set_value(false);
+        config_ui.chk_filters.set_value(false);
+        config_ui.chk_labels.set_value(false);
+        config_ui.chk_multi.set_value(false);
+
+        config_ui.radio_std_path.set_selection(0);
+
+        for fltr in config_ui.fltr.iter() {
+            fltr.set_value(false);
+        }
+
+        self.create_dir_ctrl(config_ui);
     }
 
     fn create_dir_ctrl(&self, config_ui: &ConfigUI) {

--- a/samples/widgets/src/dirctrl.rs
+++ b/samples/widgets/src/dirctrl.rs
@@ -387,6 +387,17 @@ impl DirCtrlWidgetsPage {
             .dir("/")
             .build();
 
+        let mut filter = String::new();
+        for fltr in config_ui.fltr.iter() {
+            if fltr.is_checked() {
+                if !filter.is_empty() {
+                    filter.push_str("|");
+                }
+                filter.push_str(&fltr.get_label());
+            }
+        }
+        dir_ctrl.set_filter(&filter);
+
         // update sizer's child window
         if let Some(old_dir_ctrl) = self.dir_ctrl.borrow().as_ref() {
             config_ui

--- a/samples/widgets/src/dirctrl.rs
+++ b/samples/widgets/src/dirctrl.rs
@@ -1,0 +1,261 @@
+use crate::WidgetsPage;
+use std::cell::RefCell;
+use std::os::raw::{c_int, c_long};
+use std::rc::Rc;
+use wx::methods::*;
+
+// control ids
+#[derive(Clone, Copy)]
+enum PickerPage {
+    Reset = wx::ID_HIGHEST as isize,
+    Dir,
+    SetDir,
+}
+impl PickerPage {
+    fn from(v: c_int) -> Option<Self> {
+        use PickerPage::*;
+        for e in [Reset, Dir, SetDir] {
+            if v == e.into() {
+                return Some(e);
+            }
+        }
+        return None;
+    }
+}
+impl From<PickerPage> for c_int {
+    fn from(w: PickerPage) -> Self {
+        w as c_int
+    }
+}
+
+#[derive(Clone)]
+pub struct ConfigUI {
+    // other controls
+    // --------------
+    chk_dir_text_ctrl: wx::CheckBox,
+    chk_dir_change_dir: wx::CheckBox,
+    chk_dir_must_exist: wx::CheckBox,
+    chk_small: wx::CheckBox,
+    text_initial_dir: wx::TextCtrl,
+
+    sizer: wx::BoxSizer,
+}
+
+#[derive(Clone)]
+pub struct DirPickerWidgetsPage {
+    pub base: wx::Panel,
+    config_ui: RefCell<Option<ConfigUI>>,
+    // the picker
+    dir_picker: Rc<RefCell<Option<wx::DirPickerCtrl>>>,
+}
+impl WidgetsPage for DirPickerWidgetsPage {
+    fn base(&self) -> &wx::Panel {
+        return &self.base;
+    }
+    fn label(&self) -> &str {
+        return "DirPicker";
+    }
+    fn create_content(&self) {
+        // left pane
+        let boxleft = wx::BoxSizer::new(wx::VERTICAL);
+
+        let dirbox =
+            wx::StaticBoxSizer::new_with_int(wx::VERTICAL, Some(&self.base), "&DirPicker style");
+        let chk_dir_text_ctrl =
+            self.create_check_box_and_add_to_sizer(&dirbox, "With textctrl", wx::ID_ANY);
+        let chk_dir_must_exist =
+            self.create_check_box_and_add_to_sizer(&dirbox, "Dir must exist", wx::ID_ANY);
+        let chk_dir_change_dir =
+            self.create_check_box_and_add_to_sizer(&dirbox, "Change working dir", wx::ID_ANY);
+        let chk_small =
+            self.create_check_box_and_add_to_sizer(&dirbox, "&Small version", wx::ID_ANY);
+        boxleft.add_sizer_int(Some(&dirbox), 0, wx::ALL | wx::GROW, 5, wx::Object::none());
+
+        let (sizer_initial_dir, text_initial_dir) = self.create_sizer_with_text_and_button(
+            PickerPage::SetDir.into(),
+            "&Initial directory",
+            wx::ID_ANY,
+        );
+        boxleft.add_sizer_sizerflags(
+            Some(&sizer_initial_dir),
+            wx::SizerFlags::new(0).expand().border(wx::ALL),
+        );
+
+        boxleft.add_spacer(10);
+
+        boxleft.add_window_int(
+            Some(
+                &wx::Button::builder(Some(&self.base))
+                    .id(PickerPage::Reset.into())
+                    .label("&Reset")
+                    .build(),
+            ),
+            0,
+            wx::ALIGN_CENTRE_HORIZONTAL | wx::ALL,
+            15,
+            wx::Object::none(),
+        );
+
+        let sizer = wx::BoxSizer::new(wx::VERTICAL);
+        let config_ui = ConfigUI {
+            chk_dir_text_ctrl,
+            chk_dir_change_dir,
+            chk_dir_must_exist,
+            chk_small,
+            text_initial_dir,
+
+            sizer,
+        };
+        self.reset(&config_ui); // set checkboxes state
+
+        // create pickers
+        self.create_picker(&config_ui);
+
+        // right pane
+        config_ui
+            .sizer
+            .add_int_int(1, 1, 1, wx::GROW | wx::ALL, 5, wx::Object::none());
+        // TODO: insert picker in create_picker()
+        if let Some(dir_picker) = self.dir_picker.borrow().as_ref() {
+            config_ui.sizer.add_window_int(
+                Some(dir_picker),
+                0,
+                wx::EXPAND | wx::ALL,
+                5,
+                wx::Object::none(),
+            );
+        }
+        config_ui
+            .sizer
+            .add_int_int(1, 1, 1, wx::GROW | wx::ALL, 5, wx::Object::none()); // spacer
+
+        // global pane
+        let sz = wx::BoxSizer::new(wx::HORIZONTAL);
+        sz.add_sizer_int(Some(&boxleft), 0, wx::GROW | wx::ALL, 5, wx::Object::none());
+        sz.add_sizer_int(
+            Some(&config_ui.sizer),
+            1,
+            wx::GROW | wx::ALL,
+            5,
+            wx::Object::none(),
+        );
+        *self.config_ui.borrow_mut() = Some(config_ui);
+
+        self.base.set_sizer(Some(&sz), true);
+    }
+
+    fn handle_button(&self, event: &wx::CommandEvent) {
+        println!("event={}", event.get_id());
+        if let (Some(config_ui), Some(m)) = (
+            self.config_ui.borrow().as_ref(),
+            PickerPage::from(event.get_id()),
+        ) {
+            match m {
+                PickerPage::Reset => self.on_button_reset(config_ui),
+                PickerPage::SetDir => self.on_button_set_dir(config_ui),
+                _ => (),
+            };
+        }
+    }
+    fn handle_checkbox(&self, _: &wx::CommandEvent) {
+        self.on_check_box();
+    }
+    fn handle_radiobox(&self, _: &wx::CommandEvent) {
+        // Do nothing
+    }
+}
+impl DirPickerWidgetsPage {
+    pub fn new<P: WindowMethods>(book: &P) -> Self {
+        let panel = wx::Panel::builder(Some(book))
+            .style(wx::CLIP_CHILDREN | wx::TAB_TRAVERSAL)
+            .build();
+        DirPickerWidgetsPage {
+            base: panel,
+            config_ui: RefCell::new(None),
+            dir_picker: Rc::new(RefCell::new(None)),
+        }
+    }
+
+    fn recreate_widget(&self) {
+        if let Some(config_ui) = self.config_ui.borrow().as_ref() {
+            config_ui.sizer.remove_int(1);
+            self.create_picker(config_ui);
+
+            if let Some(dir_picker) = self.dir_picker.borrow().as_ref() {
+                config_ui.sizer.insert_window_int(
+                    1,
+                    Some(dir_picker),
+                    0,
+                    wx::EXPAND | wx::ALL,
+                    5,
+                    wx::Object::none(),
+                );
+            }
+
+            config_ui.sizer.layout();
+        }
+    }
+
+    fn reset(&self, config_ui: &ConfigUI) {
+        config_ui
+            .chk_dir_text_ctrl
+            .set_value((wx::DIRP_DEFAULT_STYLE & wx::DIRP_USE_TEXTCTRL) != 0);
+        config_ui
+            .chk_dir_must_exist
+            .set_value((wx::DIRP_DEFAULT_STYLE & wx::DIRP_DIR_MUST_EXIST) != 0);
+        config_ui
+            .chk_dir_change_dir
+            .set_value((wx::DIRP_DEFAULT_STYLE & wx::DIRP_CHANGE_DIR) != 0);
+        config_ui
+            .chk_small
+            .set_value((wx::FLP_DEFAULT_STYLE & wx::DIRP_SMALL) != 0);
+    }
+
+    fn create_picker(&self, config_ui: &ConfigUI) {
+        if let Some(dir_picker) = self.dir_picker.borrow().as_ref() {
+            dir_picker.destroy();
+        }
+
+        let mut style = wx::BORDER_DEFAULT;
+
+        if config_ui.chk_dir_text_ctrl.get_value() {
+            style |= wx::DIRP_USE_TEXTCTRL as c_long;
+        }
+
+        if config_ui.chk_dir_must_exist.get_value() {
+            style |= wx::DIRP_DIR_MUST_EXIST as c_long;
+        }
+
+        if config_ui.chk_dir_change_dir.get_value() {
+            style |= wx::DIRP_CHANGE_DIR as c_long;
+        }
+
+        if config_ui.chk_small.get_value() {
+            style |= wx::DIRP_SMALL as c_long;
+        }
+
+        // FIXME: wxGetHomeDir() is needed?
+        let dir_picker = wx::DirPickerCtrl::builder(Some(&self.base))
+            .id(PickerPage::Dir.into())
+            .message("Hello!".into())
+            .style(style)
+            .build();
+
+        *self.dir_picker.borrow_mut() = Some(dir_picker);
+    }
+
+    fn on_button_set_dir(&self, config_ui: &ConfigUI) {
+        if let Some(dir_picker) = self.dir_picker.borrow().as_ref() {
+            dir_picker.set_initial_directory(&config_ui.text_initial_dir.get_value());
+        }
+    }
+
+    fn on_button_reset(&self, config_ui: &ConfigUI) {
+        self.reset(config_ui);
+        self.recreate_widget();
+    }
+
+    fn on_check_box(&self) {
+        self.recreate_widget();
+    }
+}

--- a/samples/widgets/src/dirctrl.rs
+++ b/samples/widgets/src/dirctrl.rs
@@ -359,6 +359,7 @@ impl DirCtrlWidgetsPage {
 
     fn create_dir_ctrl(&self, config_ui: &ConfigUI) {
         // TODO: wxWindowUpdateLocker
+        self.base.freeze();
 
         let mut style = wx::BORDER_DEFAULT;
         if config_ui.chk_dir_only.is_checked() {
@@ -399,6 +400,9 @@ impl DirCtrlWidgetsPage {
 
         // relayout the sizer
         config_ui.sizer.layout();
+
+        // TODO: wxWindowUpdateLocker
+        self.base.thaw();
     }
 
     fn on_button_set_dir(&self, config_ui: &ConfigUI) {

--- a/samples/widgets/src/dirctrl.rs
+++ b/samples/widgets/src/dirctrl.rs
@@ -318,26 +318,6 @@ impl DirCtrlWidgetsPage {
         }
     }
 
-    fn recreate_widget(&self) {
-        // if let Some(config_ui) = self.config_ui.borrow().as_ref() {
-        //     config_ui.sizer.remove_int(1);
-        //     self.create_dir_ctrl(config_ui);
-
-        //     if let Some(dir_ctrl) = self.dir_ctrl.borrow().as_ref() {
-        //         config_ui.sizer.insert_window_int(
-        //             1,
-        //             Some(dir_ctrl),
-        //             0,
-        //             wx::EXPAND | wx::ALL,
-        //             5,
-        //             wx::Object::none(),
-        //         );
-        //     }
-
-        //     config_ui.sizer.layout();
-        // }
-    }
-
     fn reset(&self, config_ui: &ConfigUI) {
         config_ui.path.clear();
 
@@ -390,6 +370,7 @@ impl DirCtrlWidgetsPage {
         let dir_ctrl = wx::GenericDirCtrl::builder(Some(&self.base))
             .id(DirCtrlPage::Ctrl.into())
             .dir(&path)
+            .style(style)
             .build();
 
         let mut filter = String::new();
@@ -438,6 +419,8 @@ impl DirCtrlWidgetsPage {
     }
 
     fn on_check_box(&self) {
-        self.recreate_widget();
+        if let Some(config_ui) = self.config_ui.borrow().as_ref() {
+            self.create_dir_ctrl(config_ui, false);
+        }
     }
 }

--- a/samples/widgets/src/dirctrl.rs
+++ b/samples/widgets/src/dirctrl.rs
@@ -292,11 +292,11 @@ impl WidgetsPage for DirCtrlWidgetsPage {
             self.config_ui.borrow().as_ref(),
             DirCtrlPage::from(event.get_id()),
         ) {
-            // match m {
-            //     DirCtrlPage::Reset => self.on_button_reset(config_ui),
-            //     DirCtrlPage::SetDir => self.on_button_set_dir(config_ui),
-            //     _ => (),
-            // };
+            match m {
+                DirCtrlPage::Reset => self.on_button_reset(&config_ui),
+                DirCtrlPage::SetPath => self.on_button_set_path(&config_ui),
+                _ => (),
+            };
         }
     }
     fn handle_checkbox(&self, _: &wx::CommandEvent) {
@@ -416,9 +416,13 @@ impl DirCtrlWidgetsPage {
         self.base.thaw();
     }
 
-    fn on_button_set_dir(&self, config_ui: &ConfigUI) {
+    // ----------------------------------------------------------------------------
+    // event handlers
+    // ----------------------------------------------------------------------------
+
+    fn on_button_set_path(&self, config_ui: &ConfigUI) {
         if let Some(dir_ctrl) = self.dir_ctrl.borrow().as_ref() {
-            // dir_ctrl.set_initial_directory(&config_ui.text_initial_dir.get_value());
+            dir_ctrl.set_path(&config_ui.path.get_value());
         }
     }
 

--- a/samples/widgets/src/dirctrl.rs
+++ b/samples/widgets/src/dirctrl.rs
@@ -303,7 +303,9 @@ impl WidgetsPage for DirCtrlWidgetsPage {
         self.on_check_box();
     }
     fn handle_radiobox(&self, _: &wx::CommandEvent) {
-        // Do nothing
+        if let Some(config_ui) = self.config_ui.borrow().as_ref() {
+            self.on_radio_box(config_ui);
+        }
     }
 }
 impl DirCtrlWidgetsPage {
@@ -421,6 +423,29 @@ impl DirCtrlWidgetsPage {
     fn on_check_box(&self) {
         if let Some(config_ui) = self.config_ui.borrow().as_ref() {
             self.create_dir_ctrl(config_ui, false);
+        }
+    }
+
+    fn on_radio_box(&self, config_ui: &ConfigUI) {
+        if let (Some(std_path), Some(dir_ctrl)) = (
+            StdPath::from(config_ui.radio_std_path.get_selection()),
+            self.dir_ctrl.borrow().as_ref(),
+        ) {
+            let stdp = wx::StandardPaths::get();
+
+            let path = match std_path {
+                StdPath::Config => stdp.get_config_dir(),
+                StdPath::Data => stdp.get_data_dir(),
+                StdPath::Documents => stdp.get_documents_dir(),
+                StdPath::LocalData => stdp.get_local_data_dir(),
+                StdPath::Plugins => stdp.get_plugins_dir(),
+                StdPath::Resources => stdp.get_resources_dir(),
+                StdPath::UserConfig => stdp.get_user_config_dir(),
+                StdPath::UserData => stdp.get_user_data_dir(),
+                StdPath::UserLocalData => stdp.get_user_local_data_dir(),
+                _ => "".to_owned(),
+            };
+            dir_ctrl.set_path(&path);
         }
     }
 }

--- a/samples/widgets/src/dirctrl.rs
+++ b/samples/widgets/src/dirctrl.rs
@@ -340,8 +340,7 @@ impl DirCtrlWidgetsPage {
     }
 
     fn create_dir_ctrl(&self, config_ui: &ConfigUI, default_path: bool) {
-        // TODO: wxWindowUpdateLocker
-        self.base.freeze();
+        let no_updates = wx::WindowUpdateLocker::new_with_window(Some(&self.base));
 
         let mut style = wx::BORDER_DEFAULT;
         if config_ui.chk_dir_only.is_checked() {
@@ -399,9 +398,6 @@ impl DirCtrlWidgetsPage {
 
         // relayout the sizer
         config_ui.sizer.layout();
-
-        // TODO: wxWindowUpdateLocker
-        self.base.thaw();
     }
 
     // ----------------------------------------------------------------------------

--- a/samples/widgets/src/dirctrl.rs
+++ b/samples/widgets/src/dirctrl.rs
@@ -354,10 +354,10 @@ impl DirCtrlWidgetsPage {
             fltr.set_value(false);
         }
 
-        self.create_dir_ctrl(config_ui);
+        self.create_dir_ctrl(config_ui, true);
     }
 
-    fn create_dir_ctrl(&self, config_ui: &ConfigUI) {
+    fn create_dir_ctrl(&self, config_ui: &ConfigUI, default_path: bool) {
         // TODO: wxWindowUpdateLocker
         self.base.freeze();
 
@@ -381,10 +381,15 @@ impl DirCtrlWidgetsPage {
             style |= wx::DIRCTRL_MULTIPLE as c_long;
         }
 
+        let mut path = "/".to_owned(); // wxDirDialogDefaultFolderStr
+        if !default_path {
+            if let Some(old_dir_ctrl) = self.dir_ctrl.borrow().as_ref() {
+                path = old_dir_ctrl.get_path();
+            }
+        }
         let dir_ctrl = wx::GenericDirCtrl::builder(Some(&self.base))
             .id(DirCtrlPage::Ctrl.into())
-            // wxDirDialogDefaultFolderStr
-            .dir("/")
+            .dir(&path)
             .build();
 
         let mut filter = String::new();
@@ -428,7 +433,8 @@ impl DirCtrlWidgetsPage {
 
     fn on_button_reset(&self, config_ui: &ConfigUI) {
         self.reset(config_ui);
-        self.recreate_widget();
+
+        self.create_dir_ctrl(config_ui, false);
     }
 
     fn on_check_box(&self) {

--- a/samples/widgets/src/main.rs
+++ b/samples/widgets/src/main.rs
@@ -25,6 +25,9 @@ use combobox::*;
 mod datepicker;
 use datepicker::*;
 
+mod dirctrl;
+use dirctrl::*;
+
 mod dirpicker;
 use dirpicker::*;
 
@@ -131,12 +134,14 @@ impl WidgetsFrame {
         let clrpicker_page = Rc::new(ColourPickerWidgetsPage::new(&book));
         let combobox_page = Rc::new(ComboboxWidgetsPage::new(&book));
         let datepicker_page = Rc::new(DatePickerWidgetsPage::new(&book));
+        let dirctrl_page = Rc::new(DirCtrlWidgetsPage::new(&book));
         let dirpicker_page = Rc::new(DirPickerWidgetsPage::new(&book));
         let mut frame = WidgetsFrame {
             base,
             panel,
             book,
             pages: vec![
+                dirctrl_page,
                 button_page,
                 check_box_page,
                 choice_page,

--- a/samples/widgets/src/main.rs
+++ b/samples/widgets/src/main.rs
@@ -141,13 +141,13 @@ impl WidgetsFrame {
             panel,
             book,
             pages: vec![
-                dirctrl_page,
                 button_page,
                 check_box_page,
                 choice_page,
                 clrpicker_page,
                 combobox_page,
                 datepicker_page,
+                dirctrl_page,
                 dirpicker_page,
             ],
         };

--- a/wx-base/include/generated.h
+++ b/wx-base/include/generated.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <wx/wx.h>
 #include <wx/filename.h>
+#include <wx/stdpaths.h>
 
 typedef wxDateTime::TimeZone TimeZone;
 typedef wxDateTime::Tm       Tm;
@@ -201,6 +202,35 @@ void wxObject_Ref(wxObject * self, const wxObject * clone);
 void wxObject_SetRefData(wxObject * self, wxObjectRefData * data);
 void wxObject_UnRef(wxObject * self);
 void wxObject_UnShare(wxObject * self);
+
+// CLASS: wxStandardPaths
+void wxStandardPaths_delete(wxStandardPaths *self);
+#ifdef __WXMSW__
+void wxStandardPaths_DontIgnoreAppSubDir(wxStandardPaths * self);
+#endif
+wxString *wxStandardPaths_GetAppDocumentsDir(const wxStandardPaths * self);
+wxString *wxStandardPaths_GetConfigDir(const wxStandardPaths * self);
+wxString *wxStandardPaths_GetDataDir(const wxStandardPaths * self);
+wxString *wxStandardPaths_GetDocumentsDir(const wxStandardPaths * self);
+wxString *wxStandardPaths_GetExecutablePath(const wxStandardPaths * self);
+wxString *wxStandardPaths_GetInstallPrefix(const wxStandardPaths * self);
+wxString *wxStandardPaths_GetLocalDataDir(const wxStandardPaths * self);
+wxString *wxStandardPaths_GetPluginsDir(const wxStandardPaths * self);
+wxString *wxStandardPaths_GetResourcesDir(const wxStandardPaths * self);
+wxString *wxStandardPaths_GetTempDir(const wxStandardPaths * self);
+wxString *wxStandardPaths_GetUserConfigDir(const wxStandardPaths * self);
+wxString *wxStandardPaths_GetUserDataDir(const wxStandardPaths * self);
+wxString *wxStandardPaths_GetUserLocalDataDir(const wxStandardPaths * self);
+#ifdef __WXMSW__
+void wxStandardPaths_IgnoreAppSubDir(wxStandardPaths * self, const wxString * subdir_pattern);
+void wxStandardPaths_IgnoreAppBuildSubDirs(wxStandardPaths * self);
+#endif
+void wxStandardPaths_SetInstallPrefix(wxStandardPaths * self, const wxString * prefix);
+void wxStandardPaths_UseAppInfo(wxStandardPaths * self, int info);
+wxStandardPaths * wxStandardPaths_Get();
+#ifdef __WXMSW__
+wxString *wxStandardPaths_MSWGetShellDir(int csidl);
+#endif
 
 } // extern "C"
 

--- a/wx-base/include/generated.h
+++ b/wx-base/include/generated.h
@@ -213,7 +213,9 @@ wxString *wxStandardPaths_GetConfigDir(const wxStandardPaths * self);
 wxString *wxStandardPaths_GetDataDir(const wxStandardPaths * self);
 wxString *wxStandardPaths_GetDocumentsDir(const wxStandardPaths * self);
 wxString *wxStandardPaths_GetExecutablePath(const wxStandardPaths * self);
+#ifdef __WXGTK__
 wxString *wxStandardPaths_GetInstallPrefix(const wxStandardPaths * self);
+#endif
 wxString *wxStandardPaths_GetLocalDataDir(const wxStandardPaths * self);
 wxString *wxStandardPaths_GetPluginsDir(const wxStandardPaths * self);
 wxString *wxStandardPaths_GetResourcesDir(const wxStandardPaths * self);
@@ -225,7 +227,9 @@ wxString *wxStandardPaths_GetUserLocalDataDir(const wxStandardPaths * self);
 void wxStandardPaths_IgnoreAppSubDir(wxStandardPaths * self, const wxString * subdir_pattern);
 void wxStandardPaths_IgnoreAppBuildSubDirs(wxStandardPaths * self);
 #endif
+#ifdef __WXGTK__
 void wxStandardPaths_SetInstallPrefix(wxStandardPaths * self, const wxString * prefix);
+#endif
 void wxStandardPaths_UseAppInfo(wxStandardPaths * self, int info);
 wxStandardPaths * wxStandardPaths_Get();
 #ifdef __WXMSW__

--- a/wx-base/src/generated.cpp
+++ b/wx-base/src/generated.cpp
@@ -568,9 +568,11 @@ wxString *wxStandardPaths_GetDocumentsDir(const wxStandardPaths * self) {
 wxString *wxStandardPaths_GetExecutablePath(const wxStandardPaths * self) {
     return new wxString(self->GetExecutablePath());
 }
+#ifdef __WXGTK__
 wxString *wxStandardPaths_GetInstallPrefix(const wxStandardPaths * self) {
     return new wxString(self->GetInstallPrefix());
 }
+#endif
 wxString *wxStandardPaths_GetLocalDataDir(const wxStandardPaths * self) {
     return new wxString(self->GetLocalDataDir());
 }
@@ -600,9 +602,11 @@ void wxStandardPaths_IgnoreAppBuildSubDirs(wxStandardPaths * self) {
     return self->IgnoreAppBuildSubDirs();
 }
 #endif
+#ifdef __WXGTK__
 void wxStandardPaths_SetInstallPrefix(wxStandardPaths * self, const wxString * prefix) {
     return self->SetInstallPrefix(*prefix);
 }
+#endif
 void wxStandardPaths_UseAppInfo(wxStandardPaths * self, int info) {
     return self->UseAppInfo(info);
 }

--- a/wx-base/src/generated.cpp
+++ b/wx-base/src/generated.cpp
@@ -544,5 +544,76 @@ void wxObject_UnShare(wxObject * self) {
     return self->UnShare();
 }
 
+// CLASS: wxStandardPaths
+void wxStandardPaths_delete(wxStandardPaths *self) {
+    delete self;
+}
+#ifdef __WXMSW__
+void wxStandardPaths_DontIgnoreAppSubDir(wxStandardPaths * self) {
+    return self->DontIgnoreAppSubDir();
+}
+#endif
+wxString *wxStandardPaths_GetAppDocumentsDir(const wxStandardPaths * self) {
+    return new wxString(self->GetAppDocumentsDir());
+}
+wxString *wxStandardPaths_GetConfigDir(const wxStandardPaths * self) {
+    return new wxString(self->GetConfigDir());
+}
+wxString *wxStandardPaths_GetDataDir(const wxStandardPaths * self) {
+    return new wxString(self->GetDataDir());
+}
+wxString *wxStandardPaths_GetDocumentsDir(const wxStandardPaths * self) {
+    return new wxString(self->GetDocumentsDir());
+}
+wxString *wxStandardPaths_GetExecutablePath(const wxStandardPaths * self) {
+    return new wxString(self->GetExecutablePath());
+}
+wxString *wxStandardPaths_GetInstallPrefix(const wxStandardPaths * self) {
+    return new wxString(self->GetInstallPrefix());
+}
+wxString *wxStandardPaths_GetLocalDataDir(const wxStandardPaths * self) {
+    return new wxString(self->GetLocalDataDir());
+}
+wxString *wxStandardPaths_GetPluginsDir(const wxStandardPaths * self) {
+    return new wxString(self->GetPluginsDir());
+}
+wxString *wxStandardPaths_GetResourcesDir(const wxStandardPaths * self) {
+    return new wxString(self->GetResourcesDir());
+}
+wxString *wxStandardPaths_GetTempDir(const wxStandardPaths * self) {
+    return new wxString(self->GetTempDir());
+}
+wxString *wxStandardPaths_GetUserConfigDir(const wxStandardPaths * self) {
+    return new wxString(self->GetUserConfigDir());
+}
+wxString *wxStandardPaths_GetUserDataDir(const wxStandardPaths * self) {
+    return new wxString(self->GetUserDataDir());
+}
+wxString *wxStandardPaths_GetUserLocalDataDir(const wxStandardPaths * self) {
+    return new wxString(self->GetUserLocalDataDir());
+}
+#ifdef __WXMSW__
+void wxStandardPaths_IgnoreAppSubDir(wxStandardPaths * self, const wxString * subdir_pattern) {
+    return self->IgnoreAppSubDir(*subdir_pattern);
+}
+void wxStandardPaths_IgnoreAppBuildSubDirs(wxStandardPaths * self) {
+    return self->IgnoreAppBuildSubDirs();
+}
+#endif
+void wxStandardPaths_SetInstallPrefix(wxStandardPaths * self, const wxString * prefix) {
+    return self->SetInstallPrefix(*prefix);
+}
+void wxStandardPaths_UseAppInfo(wxStandardPaths * self, int info) {
+    return self->UseAppInfo(info);
+}
+wxStandardPaths * wxStandardPaths_Get() {
+    return &(wxStandardPaths::Get());
+}
+#ifdef __WXMSW__
+wxString *wxStandardPaths_MSWGetShellDir(int csidl) {
+    return new wxString(wxStandardPaths::MSWGetShellDir(csidl));
+}
+#endif
+
 } // extern "C"
 

--- a/wx-base/src/generated.rs
+++ b/wx-base/src/generated.rs
@@ -251,3 +251,42 @@ impl<const OWNED: bool> Drop for ObjectIsOwned<OWNED> {
         }
     }
 }
+
+// wxStandardPaths
+wx_class! { StandardPaths =
+    StandardPathsIsOwned<true>(wxStandardPaths) impl
+        StandardPathsMethods
+}
+impl<const OWNED: bool> StandardPathsIsOwned<OWNED> {
+    //  ENUM: ResourceCat
+    pub const ResourceCat_None: c_int = 0;
+    pub const ResourceCat_Messages: c_int = 0 + 1;
+
+    //  ENUM: Dir
+    pub const Dir_Cache: c_int = 0;
+    pub const Dir_Documents: c_int = 0 + 1;
+    pub const Dir_Desktop: c_int = 0 + 2;
+    pub const Dir_Downloads: c_int = 0 + 3;
+    pub const Dir_Music: c_int = 0 + 4;
+    pub const Dir_Pictures: c_int = 0 + 5;
+    pub const Dir_Videos: c_int = 0 + 6;
+
+    //  ENUM: FileLayout
+    pub const FileLayout_Classic: c_int = 0;
+    pub const FileLayout_XDG: c_int = 0 + 1;
+
+    //  ENUM: ConfigFileConv
+    pub const ConfigFileConv_Dot: c_int = 0;
+    pub const ConfigFileConv_Ext: c_int = 0 + 1;
+
+    pub fn none() -> Option<&'static Self> {
+        None
+    }
+}
+impl<const OWNED: bool> Drop for StandardPathsIsOwned<OWNED> {
+    fn drop(&mut self) {
+        if OWNED {
+            unsafe { ffi::wxStandardPaths_delete(self.0) }
+        }
+    }
+}

--- a/wx-base/src/generated/ffi.rs
+++ b/wx-base/src/generated/ffi.rs
@@ -412,4 +412,32 @@ extern "C" {
     // BLOCKED: pub fn wxObject_operator delete(self_: *mut c_void, buf: *mut c_void);
     // BLOCKED: pub fn wxObject_operator new(self_: *mut c_void, size: usize, filename: *const c_void, line_num: c_int) -> *mut c_void;
 
+    // wxStandardPaths
+    pub fn wxStandardPaths_delete(self_: *mut c_void);
+    pub fn wxStandardPaths_DontIgnoreAppSubDir(self_: *mut c_void);
+    pub fn wxStandardPaths_GetAppDocumentsDir(self_: *const c_void) -> *mut c_void;
+    pub fn wxStandardPaths_GetConfigDir(self_: *const c_void) -> *mut c_void;
+    pub fn wxStandardPaths_GetDataDir(self_: *const c_void) -> *mut c_void;
+    pub fn wxStandardPaths_GetDocumentsDir(self_: *const c_void) -> *mut c_void;
+    pub fn wxStandardPaths_GetExecutablePath(self_: *const c_void) -> *mut c_void;
+    pub fn wxStandardPaths_GetInstallPrefix(self_: *const c_void) -> *mut c_void;
+    pub fn wxStandardPaths_GetLocalDataDir(self_: *const c_void) -> *mut c_void;
+    // NOT_SUPPORTED: pub fn wxStandardPaths_GetLocalizedResourcesDir(self_: *const c_void, lang: *const c_void, category: ResourceCat) -> *mut c_void;
+    pub fn wxStandardPaths_GetPluginsDir(self_: *const c_void) -> *mut c_void;
+    pub fn wxStandardPaths_GetResourcesDir(self_: *const c_void) -> *mut c_void;
+    pub fn wxStandardPaths_GetTempDir(self_: *const c_void) -> *mut c_void;
+    pub fn wxStandardPaths_GetUserConfigDir(self_: *const c_void) -> *mut c_void;
+    pub fn wxStandardPaths_GetUserDataDir(self_: *const c_void) -> *mut c_void;
+    // NOT_SUPPORTED: pub fn wxStandardPaths_GetUserDir(self_: *const c_void, user_dir: Dir) -> *mut c_void;
+    pub fn wxStandardPaths_GetUserLocalDataDir(self_: *const c_void) -> *mut c_void;
+    pub fn wxStandardPaths_IgnoreAppSubDir(self_: *mut c_void, subdir_pattern: *const c_void);
+    pub fn wxStandardPaths_IgnoreAppBuildSubDirs(self_: *mut c_void);
+    pub fn wxStandardPaths_SetInstallPrefix(self_: *mut c_void, prefix: *const c_void);
+    pub fn wxStandardPaths_UseAppInfo(self_: *mut c_void, info: c_int);
+    // NOT_SUPPORTED: pub fn wxStandardPaths_SetFileLayout(self_: *mut c_void, layout: FileLayout);
+    // NOT_SUPPORTED: pub fn wxStandardPaths_GetFileLayout(self_: *const c_void) -> FileLayout;
+    // NOT_SUPPORTED: pub fn wxStandardPaths_MakeConfigFileName(self_: *const c_void, basename: *const c_void, conv: ConfigFileConv) -> *mut c_void;
+    pub fn wxStandardPaths_Get() -> *mut c_void;
+    pub fn wxStandardPaths_MSWGetShellDir(csidl: c_int) -> *mut c_void;
+
 }

--- a/wx-base/src/generated/methods.rs
+++ b/wx-base/src/generated/methods.rs
@@ -970,3 +970,82 @@ pub trait ObjectMethods: WxRustMethods {
     // BLOCKED: fn operator delete()
     // BLOCKED: fn operator new()
 }
+
+// wxStandardPaths
+pub trait StandardPathsMethods: WxRustMethods {
+    fn dont_ignore_app_sub_dir(&self) {
+        unsafe { ffi::wxStandardPaths_DontIgnoreAppSubDir(self.as_ptr()) }
+    }
+    fn get_app_documents_dir(&self) -> String {
+        unsafe { WxString::from_ptr(ffi::wxStandardPaths_GetAppDocumentsDir(self.as_ptr())).into() }
+    }
+    fn get_config_dir(&self) -> String {
+        unsafe { WxString::from_ptr(ffi::wxStandardPaths_GetConfigDir(self.as_ptr())).into() }
+    }
+    fn get_data_dir(&self) -> String {
+        unsafe { WxString::from_ptr(ffi::wxStandardPaths_GetDataDir(self.as_ptr())).into() }
+    }
+    fn get_documents_dir(&self) -> String {
+        unsafe { WxString::from_ptr(ffi::wxStandardPaths_GetDocumentsDir(self.as_ptr())).into() }
+    }
+    fn get_executable_path(&self) -> String {
+        unsafe { WxString::from_ptr(ffi::wxStandardPaths_GetExecutablePath(self.as_ptr())).into() }
+    }
+    fn get_install_prefix(&self) -> String {
+        unsafe { WxString::from_ptr(ffi::wxStandardPaths_GetInstallPrefix(self.as_ptr())).into() }
+    }
+    fn get_local_data_dir(&self) -> String {
+        unsafe { WxString::from_ptr(ffi::wxStandardPaths_GetLocalDataDir(self.as_ptr())).into() }
+    }
+    // NOT_SUPPORTED: fn GetLocalizedResourcesDir()
+    fn get_plugins_dir(&self) -> String {
+        unsafe { WxString::from_ptr(ffi::wxStandardPaths_GetPluginsDir(self.as_ptr())).into() }
+    }
+    fn get_resources_dir(&self) -> String {
+        unsafe { WxString::from_ptr(ffi::wxStandardPaths_GetResourcesDir(self.as_ptr())).into() }
+    }
+    fn get_temp_dir(&self) -> String {
+        unsafe { WxString::from_ptr(ffi::wxStandardPaths_GetTempDir(self.as_ptr())).into() }
+    }
+    fn get_user_config_dir(&self) -> String {
+        unsafe { WxString::from_ptr(ffi::wxStandardPaths_GetUserConfigDir(self.as_ptr())).into() }
+    }
+    fn get_user_data_dir(&self) -> String {
+        unsafe { WxString::from_ptr(ffi::wxStandardPaths_GetUserDataDir(self.as_ptr())).into() }
+    }
+    // NOT_SUPPORTED: fn GetUserDir()
+    fn get_user_local_data_dir(&self) -> String {
+        unsafe {
+            WxString::from_ptr(ffi::wxStandardPaths_GetUserLocalDataDir(self.as_ptr())).into()
+        }
+    }
+    fn ignore_app_sub_dir(&self, subdir_pattern: &str) {
+        unsafe {
+            let subdir_pattern = WxString::from(subdir_pattern);
+            let subdir_pattern = subdir_pattern.as_ptr();
+            ffi::wxStandardPaths_IgnoreAppSubDir(self.as_ptr(), subdir_pattern)
+        }
+    }
+    fn ignore_app_build_sub_dirs(&self) {
+        unsafe { ffi::wxStandardPaths_IgnoreAppBuildSubDirs(self.as_ptr()) }
+    }
+    fn set_install_prefix(&self, prefix: &str) {
+        unsafe {
+            let prefix = WxString::from(prefix);
+            let prefix = prefix.as_ptr();
+            ffi::wxStandardPaths_SetInstallPrefix(self.as_ptr(), prefix)
+        }
+    }
+    fn use_app_info(&self, info: c_int) {
+        unsafe { ffi::wxStandardPaths_UseAppInfo(self.as_ptr(), info) }
+    }
+    // NOT_SUPPORTED: fn SetFileLayout()
+    // NOT_SUPPORTED: fn GetFileLayout()
+    // NOT_SUPPORTED: fn MakeConfigFileName()
+    fn get() -> StandardPathsIsOwned<false> {
+        unsafe { StandardPathsIsOwned::from_ptr(ffi::wxStandardPaths_Get()) }
+    }
+    fn msw_get_shell_dir(csidl: c_int) -> String {
+        unsafe { WxString::from_ptr(ffi::wxStandardPaths_MSWGetShellDir(csidl)).into() }
+    }
+}

--- a/wx-core/include/generated.h
+++ b/wx-core/include/generated.h
@@ -8,6 +8,7 @@
 #include <wx/dirctrl.h>
 #include <wx/filepicker.h>
 #include <wx/wrapsizer.h>
+#include <wx/wupdlock.h>
 
 // wxBitmapBundle compatibility hack(for a while)
 #if !wxCHECK_VERSION(3, 1, 6)
@@ -1531,6 +1532,12 @@ void wxWindow_UnreserveControlId(wxWindowID id, int count);
 wxWindow *wxWindow_new();
 wxWindow *wxWindow_new1(wxWindow * parent, wxWindowID id, const wxPoint * pos, const wxSize * size, long style, const wxString * name);
 bool wxWindow_Create(wxWindow * self, wxWindow * parent, wxWindowID id, const wxPoint * pos, const wxSize * size, long style, const wxString * name);
+
+// CLASS: wxWindowUpdateLocker
+void wxWindowUpdateLocker_delete(wxWindowUpdateLocker *self);
+wxWindowUpdateLocker *wxWindowUpdateLocker_new();
+wxWindowUpdateLocker *wxWindowUpdateLocker_new1(wxWindow * win);
+void wxWindowUpdateLocker_Lock(wxWindowUpdateLocker * self, wxWindow * win);
 
 // CLASS: wxWrapSizer
 wxWrapSizer *wxWrapSizer_new(int orient, int flags);

--- a/wx-core/include/generated.h
+++ b/wx-core/include/generated.h
@@ -8,7 +8,6 @@
 #include <wx/dirctrl.h>
 #include <wx/filepicker.h>
 #include <wx/wrapsizer.h>
-#include <wx/wupdlock.h>
 
 // wxBitmapBundle compatibility hack(for a while)
 #if !wxCHECK_VERSION(3, 1, 6)
@@ -1532,12 +1531,6 @@ void wxWindow_UnreserveControlId(wxWindowID id, int count);
 wxWindow *wxWindow_new();
 wxWindow *wxWindow_new1(wxWindow * parent, wxWindowID id, const wxPoint * pos, const wxSize * size, long style, const wxString * name);
 bool wxWindow_Create(wxWindow * self, wxWindow * parent, wxWindowID id, const wxPoint * pos, const wxSize * size, long style, const wxString * name);
-
-// CLASS: wxWindowUpdateLocker
-void wxWindowUpdateLocker_delete(wxWindowUpdateLocker *self);
-wxWindowUpdateLocker *wxWindowUpdateLocker_new();
-wxWindowUpdateLocker *wxWindowUpdateLocker_new1(wxWindow * win);
-void wxWindowUpdateLocker_Lock(wxWindowUpdateLocker * self, wxWindow * win);
 
 // CLASS: wxWrapSizer
 wxWrapSizer *wxWrapSizer_new(int orient, int flags);

--- a/wx-core/include/generated.h
+++ b/wx-core/include/generated.h
@@ -5,6 +5,7 @@
 #include <wx/bookctrl.h>
 #include <wx/clrpicker.h>
 #include <wx/datectrl.h>
+#include <wx/dirctrl.h>
 #include <wx/filepicker.h>
 #include <wx/wrapsizer.h>
 
@@ -376,6 +377,33 @@ void wxFrame_PushStatusText(wxFrame * self, const wxString * text, int number);
 void wxFrame_PopStatusText(wxFrame * self, int number);
 
 // CLASS: wxGDIObject
+
+// CLASS: wxGenericDirCtrl
+wxGenericDirCtrl *wxGenericDirCtrl_new();
+wxGenericDirCtrl *wxGenericDirCtrl_new1(wxWindow * parent, wxWindowID id, const wxString * dir, const wxPoint * pos, const wxSize * size, long style, const wxString * filter, int default_filter, const wxString * name);
+bool wxGenericDirCtrl_CollapsePath(wxGenericDirCtrl * self, const wxString * path);
+void wxGenericDirCtrl_CollapseTree(wxGenericDirCtrl * self);
+bool wxGenericDirCtrl_Create(wxGenericDirCtrl * self, wxWindow * parent, wxWindowID id, const wxString * dir, const wxPoint * pos, const wxSize * size, long style, const wxString * filter, int default_filter, const wxString * name);
+bool wxGenericDirCtrl_ExpandPath(wxGenericDirCtrl * self, const wxString * path);
+wxString *wxGenericDirCtrl_GetDefaultPath(const wxGenericDirCtrl * self);
+wxString *wxGenericDirCtrl_GetFilePath(const wxGenericDirCtrl * self);
+void wxGenericDirCtrl_GetFilePaths(const wxGenericDirCtrl * self, wxArrayString * paths);
+wxString *wxGenericDirCtrl_GetFilter(const wxGenericDirCtrl * self);
+int wxGenericDirCtrl_GetFilterIndex(const wxGenericDirCtrl * self);
+wxDirFilterListCtrl * wxGenericDirCtrl_GetFilterListCtrl(const wxGenericDirCtrl * self);
+wxString *wxGenericDirCtrl_GetPath(const wxGenericDirCtrl * self);
+void wxGenericDirCtrl_GetPaths(const wxGenericDirCtrl * self, wxArrayString * paths);
+wxTreeCtrl * wxGenericDirCtrl_GetTreeCtrl(const wxGenericDirCtrl * self);
+void wxGenericDirCtrl_Init(wxGenericDirCtrl * self);
+void wxGenericDirCtrl_ReCreateTree(wxGenericDirCtrl * self);
+void wxGenericDirCtrl_SetDefaultPath(wxGenericDirCtrl * self, const wxString * path);
+void wxGenericDirCtrl_SetFilter(wxGenericDirCtrl * self, const wxString * filter);
+void wxGenericDirCtrl_SetFilterIndex(wxGenericDirCtrl * self, int n);
+void wxGenericDirCtrl_SetPath(wxGenericDirCtrl * self, const wxString * path);
+void wxGenericDirCtrl_ShowHidden(wxGenericDirCtrl * self, bool show);
+void wxGenericDirCtrl_SelectPath(wxGenericDirCtrl * self, const wxString * path, bool select);
+void wxGenericDirCtrl_SelectPaths(wxGenericDirCtrl * self, const wxArrayString * paths);
+void wxGenericDirCtrl_UnselectAll(wxGenericDirCtrl * self);
 
 // CLASS: wxIcon
 wxIcon *wxIcon_new();

--- a/wx-core/src/generated.cpp
+++ b/wx-core/src/generated.cpp
@@ -4076,20 +4076,6 @@ bool wxWindow_Create(wxWindow * self, wxWindow * parent, wxWindowID id, const wx
     return self->Create(parent, id, *pos, *size, style, *name);
 }
 
-// CLASS: wxWindowUpdateLocker
-void wxWindowUpdateLocker_delete(wxWindowUpdateLocker *self) {
-    delete self;
-}
-wxWindowUpdateLocker *wxWindowUpdateLocker_new() {
-    return new wxWindowUpdateLocker();
-}
-wxWindowUpdateLocker *wxWindowUpdateLocker_new1(wxWindow * win) {
-    return new wxWindowUpdateLocker(win);
-}
-void wxWindowUpdateLocker_Lock(wxWindowUpdateLocker * self, wxWindow * win) {
-    return self->Lock(win);
-}
-
 // CLASS: wxWrapSizer
 wxWrapSizer *wxWrapSizer_new(int orient, int flags) {
     return new wxWrapSizer(orient, flags);

--- a/wx-core/src/generated.cpp
+++ b/wx-core/src/generated.cpp
@@ -4076,6 +4076,20 @@ bool wxWindow_Create(wxWindow * self, wxWindow * parent, wxWindowID id, const wx
     return self->Create(parent, id, *pos, *size, style, *name);
 }
 
+// CLASS: wxWindowUpdateLocker
+void wxWindowUpdateLocker_delete(wxWindowUpdateLocker *self) {
+    delete self;
+}
+wxWindowUpdateLocker *wxWindowUpdateLocker_new() {
+    return new wxWindowUpdateLocker();
+}
+wxWindowUpdateLocker *wxWindowUpdateLocker_new1(wxWindow * win) {
+    return new wxWindowUpdateLocker(win);
+}
+void wxWindowUpdateLocker_Lock(wxWindowUpdateLocker * self, wxWindow * win) {
+    return self->Lock(win);
+}
+
 // CLASS: wxWrapSizer
 wxWrapSizer *wxWrapSizer_new(int orient, int flags) {
     return new wxWrapSizer(orient, flags);

--- a/wx-core/src/generated.cpp
+++ b/wx-core/src/generated.cpp
@@ -888,6 +888,83 @@ void wxFrame_PopStatusText(wxFrame * self, int number) {
 
 // CLASS: wxGDIObject
 
+// CLASS: wxGenericDirCtrl
+wxGenericDirCtrl *wxGenericDirCtrl_new() {
+    return new wxGenericDirCtrl();
+}
+wxGenericDirCtrl *wxGenericDirCtrl_new1(wxWindow * parent, wxWindowID id, const wxString * dir, const wxPoint * pos, const wxSize * size, long style, const wxString * filter, int default_filter, const wxString * name) {
+    return new wxGenericDirCtrl(parent, id, *dir, *pos, *size, style, *filter, default_filter, *name);
+}
+bool wxGenericDirCtrl_CollapsePath(wxGenericDirCtrl * self, const wxString * path) {
+    return self->CollapsePath(*path);
+}
+void wxGenericDirCtrl_CollapseTree(wxGenericDirCtrl * self) {
+    return self->CollapseTree();
+}
+bool wxGenericDirCtrl_Create(wxGenericDirCtrl * self, wxWindow * parent, wxWindowID id, const wxString * dir, const wxPoint * pos, const wxSize * size, long style, const wxString * filter, int default_filter, const wxString * name) {
+    return self->Create(parent, id, *dir, *pos, *size, style, *filter, default_filter, *name);
+}
+bool wxGenericDirCtrl_ExpandPath(wxGenericDirCtrl * self, const wxString * path) {
+    return self->ExpandPath(*path);
+}
+wxString *wxGenericDirCtrl_GetDefaultPath(const wxGenericDirCtrl * self) {
+    return new wxString(self->GetDefaultPath());
+}
+wxString *wxGenericDirCtrl_GetFilePath(const wxGenericDirCtrl * self) {
+    return new wxString(self->GetFilePath());
+}
+void wxGenericDirCtrl_GetFilePaths(const wxGenericDirCtrl * self, wxArrayString * paths) {
+    return self->GetFilePaths(*paths);
+}
+wxString *wxGenericDirCtrl_GetFilter(const wxGenericDirCtrl * self) {
+    return new wxString(self->GetFilter());
+}
+int wxGenericDirCtrl_GetFilterIndex(const wxGenericDirCtrl * self) {
+    return self->GetFilterIndex();
+}
+wxDirFilterListCtrl * wxGenericDirCtrl_GetFilterListCtrl(const wxGenericDirCtrl * self) {
+    return self->GetFilterListCtrl();
+}
+wxString *wxGenericDirCtrl_GetPath(const wxGenericDirCtrl * self) {
+    return new wxString(self->GetPath());
+}
+void wxGenericDirCtrl_GetPaths(const wxGenericDirCtrl * self, wxArrayString * paths) {
+    return self->GetPaths(*paths);
+}
+wxTreeCtrl * wxGenericDirCtrl_GetTreeCtrl(const wxGenericDirCtrl * self) {
+    return self->GetTreeCtrl();
+}
+void wxGenericDirCtrl_Init(wxGenericDirCtrl * self) {
+    return self->Init();
+}
+void wxGenericDirCtrl_ReCreateTree(wxGenericDirCtrl * self) {
+    return self->ReCreateTree();
+}
+void wxGenericDirCtrl_SetDefaultPath(wxGenericDirCtrl * self, const wxString * path) {
+    return self->SetDefaultPath(*path);
+}
+void wxGenericDirCtrl_SetFilter(wxGenericDirCtrl * self, const wxString * filter) {
+    return self->SetFilter(*filter);
+}
+void wxGenericDirCtrl_SetFilterIndex(wxGenericDirCtrl * self, int n) {
+    return self->SetFilterIndex(n);
+}
+void wxGenericDirCtrl_SetPath(wxGenericDirCtrl * self, const wxString * path) {
+    return self->SetPath(*path);
+}
+void wxGenericDirCtrl_ShowHidden(wxGenericDirCtrl * self, bool show) {
+    return self->ShowHidden(show);
+}
+void wxGenericDirCtrl_SelectPath(wxGenericDirCtrl * self, const wxString * path, bool select) {
+    return self->SelectPath(*path, select);
+}
+void wxGenericDirCtrl_SelectPaths(wxGenericDirCtrl * self, const wxArrayString * paths) {
+    return self->SelectPaths(*paths);
+}
+void wxGenericDirCtrl_UnselectAll(wxGenericDirCtrl * self) {
+    return self->UnselectAll();
+}
+
 // CLASS: wxIcon
 wxIcon *wxIcon_new() {
     return new wxIcon();

--- a/wx-core/src/generated.rs
+++ b/wx-core/src/generated.rs
@@ -1860,36 +1860,6 @@ impl<const OWNED: bool> WindowIsOwned<OWNED> {
     }
 }
 
-// wxWindowUpdateLocker
-wx_class! { WindowUpdateLocker =
-    WindowUpdateLockerIsOwned<true>(wxWindowUpdateLocker) impl
-        WindowUpdateLockerMethods
-}
-impl<const OWNED: bool> WindowUpdateLockerIsOwned<OWNED> {
-    pub fn new() -> WindowUpdateLockerIsOwned<OWNED> {
-        unsafe { WindowUpdateLockerIsOwned(ffi::wxWindowUpdateLocker_new()) }
-    }
-    pub fn new_with_window<W: WindowMethods>(win: Option<&W>) -> WindowUpdateLockerIsOwned<OWNED> {
-        unsafe {
-            let win = match win {
-                Some(r) => r.as_ptr(),
-                None => ptr::null_mut(),
-            };
-            WindowUpdateLockerIsOwned(ffi::wxWindowUpdateLocker_new1(win))
-        }
-    }
-    pub fn none() -> Option<&'static Self> {
-        None
-    }
-}
-impl<const OWNED: bool> Drop for WindowUpdateLockerIsOwned<OWNED> {
-    fn drop(&mut self) {
-        if OWNED {
-            unsafe { ffi::wxWindowUpdateLocker_delete(self.0) }
-        }
-    }
-}
-
 // wxWrapSizer
 wx_class! { WrapSizer =
     WrapSizerIsOwned<true>(wxWrapSizer) impl

--- a/wx-core/src/generated.rs
+++ b/wx-core/src/generated.rs
@@ -856,6 +856,61 @@ impl<const OWNED: bool> Drop for GDIObjectIsOwned<OWNED> {
     }
 }
 
+// wxGenericDirCtrl
+wx_class! { GenericDirCtrl =
+    GenericDirCtrlIsOwned<true>(wxGenericDirCtrl) impl
+        GenericDirCtrlMethods,
+        ControlMethods,
+        WindowMethods,
+        EvtHandlerMethods,
+        ObjectMethods
+}
+impl<const OWNED: bool> GenericDirCtrlIsOwned<OWNED> {
+    pub fn new_2step() -> GenericDirCtrlIsOwned<OWNED> {
+        unsafe { GenericDirCtrlIsOwned(ffi::wxGenericDirCtrl_new()) }
+    }
+    pub fn new<W: WindowMethods, P: PointMethods, S: SizeMethods>(
+        parent: Option<&W>,
+        id: c_int,
+        dir: &str,
+        pos: &P,
+        size: &S,
+        style: c_long,
+        filter: &str,
+        default_filter: c_int,
+        name: &str,
+    ) -> GenericDirCtrlIsOwned<OWNED> {
+        unsafe {
+            let parent = match parent {
+                Some(r) => r.as_ptr(),
+                None => ptr::null_mut(),
+            };
+            let dir = WxString::from(dir);
+            let dir = dir.as_ptr();
+            let pos = pos.as_ptr();
+            let size = size.as_ptr();
+            let filter = WxString::from(filter);
+            let filter = filter.as_ptr();
+            let name = WxString::from(name);
+            let name = name.as_ptr();
+            GenericDirCtrlIsOwned(ffi::wxGenericDirCtrl_new1(
+                parent,
+                id,
+                dir,
+                pos,
+                size,
+                style,
+                filter,
+                default_filter,
+                name,
+            ))
+        }
+    }
+    pub fn none() -> Option<&'static Self> {
+        None
+    }
+}
+
 // wxIcon
 wx_class! { Icon =
     IconIsOwned<true>(wxIcon) impl

--- a/wx-core/src/generated.rs
+++ b/wx-core/src/generated.rs
@@ -1860,6 +1860,36 @@ impl<const OWNED: bool> WindowIsOwned<OWNED> {
     }
 }
 
+// wxWindowUpdateLocker
+wx_class! { WindowUpdateLocker =
+    WindowUpdateLockerIsOwned<true>(wxWindowUpdateLocker) impl
+        WindowUpdateLockerMethods
+}
+impl<const OWNED: bool> WindowUpdateLockerIsOwned<OWNED> {
+    pub fn new() -> WindowUpdateLockerIsOwned<OWNED> {
+        unsafe { WindowUpdateLockerIsOwned(ffi::wxWindowUpdateLocker_new()) }
+    }
+    pub fn new_with_window<W: WindowMethods>(win: Option<&W>) -> WindowUpdateLockerIsOwned<OWNED> {
+        unsafe {
+            let win = match win {
+                Some(r) => r.as_ptr(),
+                None => ptr::null_mut(),
+            };
+            WindowUpdateLockerIsOwned(ffi::wxWindowUpdateLocker_new1(win))
+        }
+    }
+    pub fn none() -> Option<&'static Self> {
+        None
+    }
+}
+impl<const OWNED: bool> Drop for WindowUpdateLockerIsOwned<OWNED> {
+    fn drop(&mut self) {
+        if OWNED {
+            unsafe { ffi::wxWindowUpdateLocker_delete(self.0) }
+        }
+    }
+}
+
 // wxWrapSizer
 wx_class! { WrapSizer =
     WrapSizerIsOwned<true>(wxWrapSizer) impl

--- a/wx-core/src/generated/ffi.rs
+++ b/wx-core/src/generated/ffi.rs
@@ -2679,13 +2679,6 @@ extern "C" {
         name: *const c_void,
     ) -> bool;
 
-    // wxWindowUpdateLocker
-    pub fn wxWindowUpdateLocker_delete(self_: *mut c_void);
-    pub fn wxWindowUpdateLocker_new() -> *mut c_void;
-    pub fn wxWindowUpdateLocker_new1(win: *mut c_void) -> *mut c_void;
-    pub fn wxWindowUpdateLocker_Lock(self_: *mut c_void, win: *mut c_void);
-    // DTOR: pub fn wxWindowUpdateLocker_~wxWindowUpdateLocker(self_: *mut c_void);
-
     // wxWrapSizer
     pub fn wxWrapSizer_new(orient: c_int, flags: c_int) -> *mut c_void;
 

--- a/wx-core/src/generated/ffi.rs
+++ b/wx-core/src/generated/ffi.rs
@@ -2679,6 +2679,13 @@ extern "C" {
         name: *const c_void,
     ) -> bool;
 
+    // wxWindowUpdateLocker
+    pub fn wxWindowUpdateLocker_delete(self_: *mut c_void);
+    pub fn wxWindowUpdateLocker_new() -> *mut c_void;
+    pub fn wxWindowUpdateLocker_new1(win: *mut c_void) -> *mut c_void;
+    pub fn wxWindowUpdateLocker_Lock(self_: *mut c_void, win: *mut c_void);
+    // DTOR: pub fn wxWindowUpdateLocker_~wxWindowUpdateLocker(self_: *mut c_void);
+
     // wxWrapSizer
     pub fn wxWrapSizer_new(orient: c_int, flags: c_int) -> *mut c_void;
 

--- a/wx-core/src/generated/ffi.rs
+++ b/wx-core/src/generated/ffi.rs
@@ -685,6 +685,57 @@ extern "C" {
     // wxGDIObject
     // BLOCKED: pub fn wxGDIObject_new() -> *mut c_void;
 
+    // wxGenericDirCtrl
+    pub fn wxGenericDirCtrl_new() -> *mut c_void;
+    pub fn wxGenericDirCtrl_new1(
+        parent: *mut c_void,
+        id: c_int,
+        dir: *const c_void,
+        pos: *const c_void,
+        size: *const c_void,
+        style: c_long,
+        filter: *const c_void,
+        default_filter: c_int,
+        name: *const c_void,
+    ) -> *mut c_void;
+    // DTOR: pub fn wxGenericDirCtrl_~wxGenericDirCtrl(self_: *mut c_void);
+    pub fn wxGenericDirCtrl_CollapsePath(self_: *mut c_void, path: *const c_void) -> bool;
+    pub fn wxGenericDirCtrl_CollapseTree(self_: *mut c_void);
+    pub fn wxGenericDirCtrl_Create(
+        self_: *mut c_void,
+        parent: *mut c_void,
+        id: c_int,
+        dir: *const c_void,
+        pos: *const c_void,
+        size: *const c_void,
+        style: c_long,
+        filter: *const c_void,
+        default_filter: c_int,
+        name: *const c_void,
+    ) -> bool;
+    pub fn wxGenericDirCtrl_ExpandPath(self_: *mut c_void, path: *const c_void) -> bool;
+    pub fn wxGenericDirCtrl_GetDefaultPath(self_: *const c_void) -> *mut c_void;
+    pub fn wxGenericDirCtrl_GetFilePath(self_: *const c_void) -> *mut c_void;
+    pub fn wxGenericDirCtrl_GetFilePaths(self_: *const c_void, paths: *mut c_void);
+    pub fn wxGenericDirCtrl_GetFilter(self_: *const c_void) -> *mut c_void;
+    pub fn wxGenericDirCtrl_GetFilterIndex(self_: *const c_void) -> c_int;
+    pub fn wxGenericDirCtrl_GetFilterListCtrl(self_: *const c_void) -> *mut c_void;
+    pub fn wxGenericDirCtrl_GetPath(self_: *const c_void) -> *mut c_void;
+    // NOT_SUPPORTED: pub fn wxGenericDirCtrl_GetPath1(self_: *const c_void, item_id: wxTreeItemId) -> *mut c_void;
+    pub fn wxGenericDirCtrl_GetPaths(self_: *const c_void, paths: *mut c_void);
+    // NOT_SUPPORTED: pub fn wxGenericDirCtrl_GetRootId(self_: *mut c_void) -> wxTreeItemId;
+    pub fn wxGenericDirCtrl_GetTreeCtrl(self_: *const c_void) -> *mut c_void;
+    pub fn wxGenericDirCtrl_Init(self_: *mut c_void);
+    pub fn wxGenericDirCtrl_ReCreateTree(self_: *mut c_void);
+    pub fn wxGenericDirCtrl_SetDefaultPath(self_: *mut c_void, path: *const c_void);
+    pub fn wxGenericDirCtrl_SetFilter(self_: *mut c_void, filter: *const c_void);
+    pub fn wxGenericDirCtrl_SetFilterIndex(self_: *mut c_void, n: c_int);
+    pub fn wxGenericDirCtrl_SetPath(self_: *mut c_void, path: *const c_void);
+    pub fn wxGenericDirCtrl_ShowHidden(self_: *mut c_void, show: bool);
+    pub fn wxGenericDirCtrl_SelectPath(self_: *mut c_void, path: *const c_void, select: bool);
+    pub fn wxGenericDirCtrl_SelectPaths(self_: *mut c_void, paths: *const c_void);
+    pub fn wxGenericDirCtrl_UnselectAll(self_: *mut c_void);
+
     // wxIcon
     pub fn wxIcon_new() -> *mut c_void;
     pub fn wxIcon_new1(icon: *const c_void) -> *mut c_void;

--- a/wx-core/src/generated/methods.rs
+++ b/wx-core/src/generated/methods.rs
@@ -1523,6 +1523,145 @@ pub trait FrameMethods: TopLevelWindowMethods {
 // wxGDIObject
 pub trait GDIObjectMethods: ObjectMethods {}
 
+// wxGenericDirCtrl
+pub trait GenericDirCtrlMethods: ControlMethods {
+    // DTOR: fn ~wxGenericDirCtrl()
+    fn collapse_path(&self, path: &str) -> bool {
+        unsafe {
+            let path = WxString::from(path);
+            let path = path.as_ptr();
+            ffi::wxGenericDirCtrl_CollapsePath(self.as_ptr(), path)
+        }
+    }
+    fn collapse_tree(&self) {
+        unsafe { ffi::wxGenericDirCtrl_CollapseTree(self.as_ptr()) }
+    }
+    fn create_str<W: WindowMethods, P: PointMethods, S: SizeMethods>(
+        &self,
+        parent: Option<&W>,
+        id: c_int,
+        dir: &str,
+        pos: &P,
+        size: &S,
+        style: c_long,
+        filter: &str,
+        default_filter: c_int,
+        name: &str,
+    ) -> bool {
+        unsafe {
+            let parent = match parent {
+                Some(r) => r.as_ptr(),
+                None => ptr::null_mut(),
+            };
+            let dir = WxString::from(dir);
+            let dir = dir.as_ptr();
+            let pos = pos.as_ptr();
+            let size = size.as_ptr();
+            let filter = WxString::from(filter);
+            let filter = filter.as_ptr();
+            let name = WxString::from(name);
+            let name = name.as_ptr();
+            ffi::wxGenericDirCtrl_Create(
+                self.as_ptr(),
+                parent,
+                id,
+                dir,
+                pos,
+                size,
+                style,
+                filter,
+                default_filter,
+                name,
+            )
+        }
+    }
+    fn expand_path(&self, path: &str) -> bool {
+        unsafe {
+            let path = WxString::from(path);
+            let path = path.as_ptr();
+            ffi::wxGenericDirCtrl_ExpandPath(self.as_ptr(), path)
+        }
+    }
+    fn get_default_path(&self) -> String {
+        unsafe { WxString::from_ptr(ffi::wxGenericDirCtrl_GetDefaultPath(self.as_ptr())).into() }
+    }
+    fn get_file_path(&self) -> String {
+        unsafe { WxString::from_ptr(ffi::wxGenericDirCtrl_GetFilePath(self.as_ptr())).into() }
+    }
+    fn get_file_paths(&self, paths: *mut c_void) {
+        unsafe { ffi::wxGenericDirCtrl_GetFilePaths(self.as_ptr(), paths) }
+    }
+    fn get_filter(&self) -> String {
+        unsafe { WxString::from_ptr(ffi::wxGenericDirCtrl_GetFilter(self.as_ptr())).into() }
+    }
+    fn get_filter_index(&self) -> c_int {
+        unsafe { ffi::wxGenericDirCtrl_GetFilterIndex(self.as_ptr()) }
+    }
+    fn get_filter_list_ctrl(&self) -> *mut c_void {
+        unsafe { ffi::wxGenericDirCtrl_GetFilterListCtrl(self.as_ptr()) }
+    }
+    fn get_path(&self) -> String {
+        unsafe { WxString::from_ptr(ffi::wxGenericDirCtrl_GetPath(self.as_ptr())).into() }
+    }
+    // NOT_SUPPORTED: fn GetPath1()
+    fn get_paths(&self, paths: *mut c_void) {
+        unsafe { ffi::wxGenericDirCtrl_GetPaths(self.as_ptr(), paths) }
+    }
+    // NOT_SUPPORTED: fn GetRootId()
+    fn get_tree_ctrl(&self) -> *mut c_void {
+        unsafe { ffi::wxGenericDirCtrl_GetTreeCtrl(self.as_ptr()) }
+    }
+    fn init(&self) {
+        unsafe { ffi::wxGenericDirCtrl_Init(self.as_ptr()) }
+    }
+    fn re_create_tree(&self) {
+        unsafe { ffi::wxGenericDirCtrl_ReCreateTree(self.as_ptr()) }
+    }
+    fn set_default_path(&self, path: &str) {
+        unsafe {
+            let path = WxString::from(path);
+            let path = path.as_ptr();
+            ffi::wxGenericDirCtrl_SetDefaultPath(self.as_ptr(), path)
+        }
+    }
+    fn set_filter(&self, filter: &str) {
+        unsafe {
+            let filter = WxString::from(filter);
+            let filter = filter.as_ptr();
+            ffi::wxGenericDirCtrl_SetFilter(self.as_ptr(), filter)
+        }
+    }
+    fn set_filter_index(&self, n: c_int) {
+        unsafe { ffi::wxGenericDirCtrl_SetFilterIndex(self.as_ptr(), n) }
+    }
+    fn set_path(&self, path: &str) {
+        unsafe {
+            let path = WxString::from(path);
+            let path = path.as_ptr();
+            ffi::wxGenericDirCtrl_SetPath(self.as_ptr(), path)
+        }
+    }
+    fn show_hidden(&self, show: bool) {
+        unsafe { ffi::wxGenericDirCtrl_ShowHidden(self.as_ptr(), show) }
+    }
+    fn select_path(&self, path: &str, select: bool) {
+        unsafe {
+            let path = WxString::from(path);
+            let path = path.as_ptr();
+            ffi::wxGenericDirCtrl_SelectPath(self.as_ptr(), path, select)
+        }
+    }
+    fn select_paths<A: ArrayStringMethods>(&self, paths: &A) {
+        unsafe {
+            let paths = paths.as_ptr();
+            ffi::wxGenericDirCtrl_SelectPaths(self.as_ptr(), paths)
+        }
+    }
+    fn unselect_all(&self) {
+        unsafe { ffi::wxGenericDirCtrl_UnselectAll(self.as_ptr()) }
+    }
+}
+
 // wxIcon
 pub trait IconMethods: GDIObjectMethods {
     // DTOR: fn ~wxIcon()

--- a/wx-core/src/generated/methods.rs
+++ b/wx-core/src/generated/methods.rs
@@ -7038,19 +7038,5 @@ pub trait WindowMethods: EvtHandlerMethods {
     }
 }
 
-// wxWindowUpdateLocker
-pub trait WindowUpdateLockerMethods: WxRustMethods {
-    fn lock<W: WindowMethods>(&self, win: Option<&W>) {
-        unsafe {
-            let win = match win {
-                Some(r) => r.as_ptr(),
-                None => ptr::null_mut(),
-            };
-            ffi::wxWindowUpdateLocker_Lock(self.as_ptr(), win)
-        }
-    }
-    // DTOR: fn ~wxWindowUpdateLocker()
-}
-
 // wxWrapSizer
 pub trait WrapSizerMethods: BoxSizerMethods {}

--- a/wx-core/src/generated/methods.rs
+++ b/wx-core/src/generated/methods.rs
@@ -7038,5 +7038,19 @@ pub trait WindowMethods: EvtHandlerMethods {
     }
 }
 
+// wxWindowUpdateLocker
+pub trait WindowUpdateLockerMethods: WxRustMethods {
+    fn lock<W: WindowMethods>(&self, win: Option<&W>) {
+        unsafe {
+            let win = match win {
+                Some(r) => r.as_ptr(),
+                None => ptr::null_mut(),
+            };
+            ffi::wxWindowUpdateLocker_Lock(self.as_ptr(), win)
+        }
+    }
+    // DTOR: fn ~wxWindowUpdateLocker()
+}
+
 // wxWrapSizer
 pub trait WrapSizerMethods: BoxSizerMethods {}

--- a/wx-core/src/lib.rs
+++ b/wx-core/src/lib.rs
@@ -767,6 +767,76 @@ impl<'a, P: WindowMethods> ComboBoxBuilder<'a, P> {
     }
 }
 
+pub struct GenericDirCtrlBuilder<'a, P: WindowMethods> {
+    parent: Option<&'a P>,
+    id: c_int,
+    dir: String,
+    pos: Option<Point>,
+    size: Option<Size>,
+    style: c_long,
+    filter: String,
+    default_filter: c_int,
+}
+impl<'a, P: WindowMethods> Buildable<'a, P, GenericDirCtrlBuilder<'a, P>> for GenericDirCtrl {
+    fn builder(parent: Option<&'a P>) -> GenericDirCtrlBuilder<'a, P> {
+        GenericDirCtrlBuilder {
+            parent: parent,
+            id: ID_ANY,
+            dir: "".to_string(),
+            pos: None,
+            size: None,
+            style: 0,
+            filter: "".to_string(),
+            default_filter: 0,
+        }
+    }
+}
+impl<'a, P: WindowMethods> GenericDirCtrlBuilder<'a, P> {
+    pub fn id(&mut self, id: c_int) -> &mut Self {
+        self.id = id;
+        self
+    }
+    pub fn dir(&mut self, dir: &str) -> &mut Self {
+        self.dir = dir.to_string();
+        self
+    }
+    pub fn pos(&mut self, pos: Point) -> &mut Self {
+        self.pos = Some(pos);
+        self
+    }
+    pub fn size(&mut self, size: Size) -> &mut Self {
+        self.size = Some(size);
+        self
+    }
+    pub fn style(&mut self, style: c_long) -> &mut Self {
+        self.style = style;
+        self
+    }
+    pub fn filter(&mut self, filter: &str) -> &mut Self {
+        self.filter = filter.to_string();
+        self
+    }
+    pub fn default_filter(&mut self, default_filter: c_int) -> &mut Self {
+        self.default_filter = default_filter;
+        self
+    }
+    pub fn build(&mut self) -> GenericDirCtrl {
+        let pos = self.pos.take().unwrap_or_else(|| Point::default());
+        let size = self.size.take().unwrap_or_else(|| Size::default());
+        GenericDirCtrl::new(
+            self.parent,
+            self.id,
+            &self.dir,
+            &pos,
+            &size,
+            self.style,
+            &self.filter,
+            self.default_filter,
+            "",
+        )
+    }
+}
+
 pub struct ListBoxBuilder<'a, P: WindowMethods> {
     parent: Option<&'a P>,
     id: c_int,

--- a/wx-core/src/lib.rs
+++ b/wx-core/src/lib.rs
@@ -1336,6 +1336,25 @@ impl From<Bitmap> for BitmapBundle {
     }
 }
 
+// FIXME: wxWindowUpdateLocker shim for wx3.0.x
+// TODO: use generated code once dropped wx3.0.x support
+pub struct WindowUpdateLocker<'a, T: WindowMethods>(Option<&'a T>);
+impl<'a, T: WindowMethods> WindowUpdateLocker<'a, T> {
+    pub fn new_with_window(window: Option<&'a T>) -> Self {
+        if let Some(window) = window {
+            window.freeze();
+        }
+        WindowUpdateLocker(window)
+    }
+}
+impl<'a, T: WindowMethods> Drop for WindowUpdateLocker<'a, T> {
+    fn drop(&mut self) {
+        if let Some(window) = self.0 {
+            window.thaw();
+        }
+    }
+}
+
 pub fn message_box<T: WindowMethods>(
     message: &str,
     caption: &str,


### PR DESCRIPTION
part of #61

Roughly implemented DirCtrl page with:

- Generate wxGenericDirCtrl binding
- Make wx::GenericDirCtrl's builder
- Generate wxStandardPath binding
- ~~Generate wxWindowUpdateLocker binding~~
  - Simulate the class's behavior with Rust implementation for wx3.0.x compatibility