### PR TITLE
Fix sample warnings

### DIFF
--- a/samples/widgets/src/button.rs
+++ b/samples/widgets/src/button.rs
@@ -35,9 +35,9 @@ impl From<ButtonPage> for c_int {
 }
 
 const BUTTON_IMAGE_POS_LEFT: c_int = 0;
-const BUTTON_IMAGE_POS_RIGHT: c_int = 1;
-const BUTTON_IMAGE_POS_TOP: c_int = 2;
-const BUTTON_IMAGE_POS_BOTTOM: c_int = 3;
+// const BUTTON_IMAGE_POS_RIGHT: c_int = 1;
+// const BUTTON_IMAGE_POS_TOP: c_int = 2;
+// const BUTTON_IMAGE_POS_BOTTOM: c_int = 3;
 
 const BUTTON_HALIGN_LEFT: c_int = 0;
 const BUTTON_HALIGN_CENTRE: c_int = 1;
@@ -323,10 +323,6 @@ impl ButtonWidgetsPage {
             config_ui: RefCell::new(None),
             button: Rc::new(RefCell::new(None)),
         }
-    }
-
-    fn recreate_widget(&self) {
-        self.create_button();
     }
 
     fn reset(&self) {

--- a/samples/widgets/src/checkbox.rs
+++ b/samples/widgets/src/checkbox.rs
@@ -256,10 +256,6 @@ impl CheckBoxWidgetsPage {
         }
     }
 
-    fn recreate_widget(&self) {
-        self.create_check_box();
-    }
-
     fn reset(&self) {
         if let Some(config_ui) = self.config_ui.borrow().as_ref() {
             config_ui.chk_right.set_value(false);

--- a/samples/widgets/src/choice.rs
+++ b/samples/widgets/src/choice.rs
@@ -269,7 +269,7 @@ impl WidgetsPage for ChoiceWidgetsPage {
             };
         }
     }
-    fn handle_checkbox(&self, event: &wx::CommandEvent) {
+    fn handle_checkbox(&self, _: &wx::CommandEvent) {
         self.on_check_or_radio_box();
     }
     fn handle_radiobox(&self, _: &wx::CommandEvent) {
@@ -287,10 +287,6 @@ impl ChoiceWidgetsPage {
             choice: Rc::new(RefCell::new(None)),
             s_item: RefCell::new(1),
         }
-    }
-
-    fn recreate_widget(&self) {
-        self.create_choice();
     }
 
     fn reset(&self) {

--- a/samples/widgets/src/clrpicker.rs
+++ b/samples/widgets/src/clrpicker.rs
@@ -10,17 +10,6 @@ enum PickerPage {
     Reset = wx::ID_HIGHEST as isize,
     Colour,
 }
-impl PickerPage {
-    fn from(v: c_int) -> Option<Self> {
-        use PickerPage::*;
-        for e in [Reset, Colour] {
-            if v == e.into() {
-                return Some(e);
-            }
-        }
-        return None;
-    }
-}
 impl From<PickerPage> for c_int {
     fn from(w: PickerPage) -> Self {
         w as c_int

--- a/samples/widgets/src/combobox.rs
+++ b/samples/widgets/src/combobox.rs
@@ -76,7 +76,7 @@ impl From<ComboPage> for c_int {
     }
 }
 
-const COMBO_KIND_DEFAULT: c_int = 0;
+// const COMBO_KIND_DEFAULT: c_int = 0;
 const COMBO_KIND_SIMPLE: c_int = 1;
 const COMBO_KIND_DROP_DOWN: c_int = 2;
 
@@ -443,7 +443,7 @@ impl WidgetsPage for ComboboxWidgetsPage {
             };
         }
     }
-    fn handle_checkbox(&self, event: &wx::CommandEvent) {
+    fn handle_checkbox(&self, _: &wx::CommandEvent) {
         self.on_check_or_radio_box();
     }
     fn handle_radiobox(&self, _: &wx::CommandEvent) {
@@ -462,10 +462,6 @@ impl ComboboxWidgetsPage {
             combobox1: Rc::new(RefCell::new(None)),
             s_item: RefCell::new(1),
         }
-    }
-
-    fn recreate_widget(&self) {
-        self.create_combo();
     }
 
     // ----------------------------------------------------------------------------

--- a/samples/widgets/src/datepicker.rs
+++ b/samples/widgets/src/datepicker.rs
@@ -179,14 +179,14 @@ impl WidgetsPage for DatePickerWidgetsPage {
         sizer_top.add_sizer_int(
             Some(&sizer_left),
             0,
-            (wx::ALL & !wx::LEFT),
+            wx::ALL & !wx::LEFT,
             10,
             wx::Object::none(),
         );
         sizer_top.add_sizer_int(
             Some(&sizer_middle),
             0,
-            (wx::TOP | wx::BOTTOM),
+            wx::TOP | wx::BOTTOM,
             10,
             wx::Object::none(),
         );
@@ -249,12 +249,6 @@ impl DatePickerWidgetsPage {
             base: panel,
             config_ui: RefCell::new(None),
             date_picker: Rc::new(RefCell::new(None)),
-        }
-    }
-
-    fn recreate_widget(&self) {
-        if let Some(config_ui) = self.config_ui.borrow().as_ref() {
-            self.create_date_picker(config_ui);
         }
     }
 

--- a/samples/widgets/src/dirctrl.rs
+++ b/samples/widgets/src/dirctrl.rs
@@ -242,7 +242,7 @@ impl WidgetsPage for DirCtrlWidgetsPage {
         sizer_top.add_sizer_int(
             Some(&sizer_left),
             0,
-            (wx::ALL & !wx::LEFT),
+            wx::ALL & !wx::LEFT,
             10,
             wx::Object::none(),
         );
@@ -335,7 +335,7 @@ impl DirCtrlWidgetsPage {
     }
 
     fn create_dir_ctrl(&self, config_ui: &ConfigUI, default_path: bool) {
-        let no_updates = wx::WindowUpdateLocker::new_with_window(Some(&self.base));
+        let _no_updates = wx::WindowUpdateLocker::new_with_window(Some(&self.base));
 
         let mut style = wx::BORDER_DEFAULT;
         if config_ui.chk_dir_only.is_checked() {

--- a/samples/widgets/src/filectrl.rs
+++ b/samples/widgets/src/filectrl.rs
@@ -92,7 +92,7 @@ impl WidgetsPage for FileCtrlWidgetsPage {
         // left pane
         let sizer_left = wx::BoxSizer::new(wx::VERTICAL);
 
-        let mut mode = wx::ArrayString::new();
+        let mode = wx::ArrayString::new();
         mode.add("open");
         mode.add("save");
         let radio_file_ctrl_mode = wx::RadioBox::builder(Some(&self.base))
@@ -192,7 +192,7 @@ impl WidgetsPage for FileCtrlWidgetsPage {
         sizer_top.add_sizer_int(
             Some(&sizer_left),
             0,
-            (wx::ALL & !wx::LEFT),
+            wx::ALL & !wx::LEFT,
             10,
             wx::Object::none(),
         );
@@ -274,7 +274,7 @@ impl FileCtrlWidgetsPage {
     }
 
     fn create_file_ctrl(&self, config_ui: &ConfigUI) {
-        let no_updates = wx::WindowUpdateLocker::new_with_window(Some(&self.base));
+        let _no_updates = wx::WindowUpdateLocker::new_with_window(Some(&self.base));
 
         let mut style = wx::BORDER_DEFAULT;
 

--- a/samples/widgets/src/fontpicker.rs
+++ b/samples/widgets/src/fontpicker.rs
@@ -10,17 +10,6 @@ enum PickerPage {
     Reset = wx::ID_HIGHEST as isize,
     Font,
 }
-impl PickerPage {
-    fn from(v: c_int) -> Option<Self> {
-        use PickerPage::*;
-        for e in [Reset, Font] {
-            if v == e.into() {
-                return Some(e);
-            }
-        }
-        return None;
-    }
-}
 impl From<PickerPage> for c_int {
     fn from(w: PickerPage) -> Self {
         w as c_int

--- a/samples/widgets/src/gauge.rs
+++ b/samples/widgets/src/gauge.rs
@@ -346,7 +346,7 @@ impl GaugeWidgetsPage {
     }
 
     fn start_timer<W: WindowMethods>(&self, clicked: &W) {
-        let INTERVAL = 300;
+        let interval = 300;
 
         let is_progress_button = clicked.get_id() == GaugePage::Progress.into();
         let timer = wx::Timer::new_with_evthandler(
@@ -357,7 +357,7 @@ impl GaugeWidgetsPage {
                 GaugePage::IndeterminateTimer.into()
             },
         );
-        timer.start(INTERVAL, wx::TIMER_CONTINUOUS);
+        timer.start(interval, wx::TIMER_CONTINUOUS);
         *self.timer.borrow_mut() = Some(timer);
 
         clicked.set_label("&Stop timer");

--- a/samples/widgets/src/main.rs
+++ b/samples/widgets/src/main.rs
@@ -47,7 +47,7 @@ mod headerctrl;
 use headerctrl::*;
 
 enum Widgets {
-    ClearLog = 100,
+    _ClearLog = 100,
     Quit,
 
     BookCtrl,
@@ -79,7 +79,7 @@ enum Widgets {
     BusyCursor,
 
     GoToPage,
-    GoToPageLast = Widgets::GoToPage as isize + 100,
+    // GoToPageLast = Widgets::GoToPage as isize + 100,
 
     End,
 }
@@ -98,9 +98,9 @@ enum TextEntry {
     AutoCompleteKeyLength,
 
     SetHint,
-    End,
+    // End,
 }
-const TEXT_ENTRY_BEGIN: c_int = TextEntry::DisableAutoComplete as c_int;
+// const TEXT_ENTRY_BEGIN: c_int = TextEntry::DisableAutoComplete as c_int;
 impl From<TextEntry> for c_int {
     fn from(te: TextEntry) -> Self {
         te as c_int
@@ -343,9 +343,9 @@ impl WidgetsFrame {
         &self.pages[index]
     }
 
-    fn connect_to_widget_events(&self) {
-        // TODO
-    }
+    // fn connect_to_widget_events(&self) {
+    //     // TODO
+    // }
 
     fn on_page_changed(&self, sel: c_int) {
         let menu_bar = self.base.get_menu_bar().get().unwrap();

--- a/samples/widgets/src/main.rs
+++ b/samples/widgets/src/main.rs
@@ -80,7 +80,7 @@ enum Widgets {
 
     GoToPage,
     // GoToPageLast = Widgets::GoToPage as isize + 100,
-
+    //
     End,
 }
 impl From<Widgets> for c_int {

--- a/samples/wrapsizer/src/main.rs
+++ b/samples/wrapsizer/src/main.rs
@@ -5,7 +5,7 @@ use wx::methods::*;
 
 fn main() {
     wx::App::run(|_| {
-        let frame = WrapSizerFrame::new();
+        let _frame = WrapSizerFrame::new();
     });
 }
 


### PR DESCRIPTION
Fix warnings in ported samples
- remove unused function
- remove, prefix underscore or comment out unread variables