### PR TITLE
Safe up downcast

### DIFF
--- a/doxybindgen/binding.py
+++ b/doxybindgen/binding.py
@@ -58,7 +58,7 @@ class RustClassBinding:
             yield '}'
             for line in self._impl_with_ctors():
                 yield line
-            for line in self._impl_class_info_if_needed():
+            for line in self._impl_dynamic_cast_if_needed():
                 yield line
             for line in self._impl_drop_if_needed():
                 yield line
@@ -92,7 +92,7 @@ class RustClassBinding:
         yield '    }'
         yield '}'
     
-    def _impl_class_info_if_needed(self):
+    def _impl_dynamic_cast_if_needed(self):
         if not self.is_a('wxObject'):
             return
         yield 'impl<const OWNED: bool> DynamicCast for %sIsOwned<OWNED> {' % (self.__model.unprefixed(),)

--- a/doxybindgen/binding.py
+++ b/doxybindgen/binding.py
@@ -104,9 +104,7 @@ class RustClassBinding:
                 unprefixed,
                 unprefixed_ancestor,
             )
-            yield '    fn from(o: %sIsOwned<OWNED>) -> Self {' % (
-                unprefixed,
-            )
+            yield '    fn from(o: %sIsOwned<OWNED>) -> Self {' % (unprefixed,)
             yield '        unsafe { Self::from_ptr(o.as_ptr()) }'
             yield '    }'
             yield '}'

--- a/doxybindgen/binding.py
+++ b/doxybindgen/binding.py
@@ -95,7 +95,7 @@ class RustClassBinding:
     def _impl_class_info_if_needed(self):
         if not self.is_a('wxObject'):
             return
-        yield 'impl<const OWNED: bool> ClassInfoMacro for %sIsOwned<OWNED> {' % (self.__model.unprefixed(),)
+        yield 'impl<const OWNED: bool> DynamicCast for %sIsOwned<OWNED> {' % (self.__model.unprefixed(),)
         yield '    fn class_info() -> ClassInfoIsOwned<false> {'
         yield '        unsafe { ClassInfoIsOwned::from_ptr(ffi::%s_CLASSINFO()) }' % (self.__model.name)
         yield '    }'

--- a/doxybindgen/binding.py
+++ b/doxybindgen/binding.py
@@ -107,9 +107,7 @@ class RustClassBinding:
             yield '    fn from(o: %sIsOwned<OWNED>) -> Self {' % (
                 unprefixed,
             )
-            yield '        unsafe { %sIsOwned::from_ptr(o.as_ptr()) }' % (
-                unprefixed_ancestor,
-            )
+            yield '        unsafe { Self::from_ptr(o.as_ptr()) }'
             yield '    }'
             yield '}'
 

--- a/samples/widgets/src/listbox.rs
+++ b/samples/widgets/src/listbox.rs
@@ -530,9 +530,7 @@ impl ListboxWidgetsPage {
                 items.add(&lbox.get_string(n));
             }
 
-            if lbox.is_kind_of(Some(&wx::CheckListBox::class_info())) {
-                // TODO: safe downcasting
-                let check_lbox = unsafe { wx::CheckListBox::from_unowned_ptr(lbox.as_ptr()) };
+            if let Ok(check_lbox) = wx::CheckListBoxIsOwned::<false>::try_from(lbox) {
                 for n in 0..count {
                     order.push(check_lbox.is_checked(n));
                 }

--- a/samples/widgets/src/listbox.rs
+++ b/samples/widgets/src/listbox.rs
@@ -530,7 +530,7 @@ impl ListboxWidgetsPage {
                 items.add(&lbox.get_string(n));
             }
 
-            if let Ok(check_lbox) = wx::CheckListBoxIsOwned::<false>::try_from(lbox) {
+            if let Some(check_lbox) = lbox.as_unowned::<wx::CheckListBox>() {
                 for n in 0..count {
                     order.push(check_lbox.is_checked(n));
                 }

--- a/samples/widgets/src/listbox.rs
+++ b/samples/widgets/src/listbox.rs
@@ -553,8 +553,7 @@ impl ListboxWidgetsPage {
                     for n in 0..order.len() {
                         check_lbox.check(n as u32, order[n]);
                     }
-                    // TODO: Support safe upcasting
-                    unsafe { wx::ListBox::from_ptr(check_lbox.as_ptr()) }
+                    check_lbox.into()
                 }
                 // LboxType::RearrangeList => {
                 //     // TODO

--- a/wx-base/include/generated.h
+++ b/wx-base/include/generated.h
@@ -87,6 +87,7 @@ wxDateTime *wxDateTime_Today();
 wxDateTime *wxDateTime_UNow();
 
 // CLASS: wxEvent
+wxClassInfo *wxEvent_CLASSINFO();
 wxEvent * wxEvent_Clone(const wxEvent * self);
 wxObject * wxEvent_GetEventObject(const wxEvent * self);
 int wxEvent_GetId(const wxEvent * self);
@@ -103,6 +104,7 @@ void wxEvent_Skip(wxEvent * self, bool skip);
 int wxEvent_StopPropagation(wxEvent * self);
 
 // CLASS: wxEvtHandler
+wxClassInfo *wxEvtHandler_CLASSINFO();
 void wxEvtHandler_QueueEvent(wxEvtHandler * self, wxEvent * event);
 void wxEvtHandler_AddPendingEvent(wxEvtHandler * self, const wxEvent * event);
 bool wxEvtHandler_ProcessEvent(wxEvtHandler * self, wxEvent * event);
@@ -203,6 +205,7 @@ wxString *wxFileName_FileNameToURL(const wxFileName * filename);
 wxString *wxFileName_StripExtension(const wxString * fullname);
 
 // CLASS: wxObject
+wxClassInfo *wxObject_CLASSINFO();
 wxObject *wxObject_new();
 wxObject *wxObject_new1(const wxObject * other);
 wxClassInfo * wxObject_GetClassInfo(const wxObject * self);
@@ -248,6 +251,7 @@ wxString *wxStandardPaths_MSWGetShellDir(int csidl);
 #endif
 
 // CLASS: wxTimer
+wxClassInfo *wxTimer_CLASSINFO();
 wxTimer *wxTimer_new();
 wxTimer *wxTimer_new1(wxEvtHandler * owner, int id);
 int wxTimer_GetId(const wxTimer * self);
@@ -262,6 +266,7 @@ bool wxTimer_StartOnce(wxTimer * self, int milliseconds);
 void wxTimer_Stop(wxTimer * self);
 
 // CLASS: wxTimerEvent
+wxClassInfo *wxTimerEvent_CLASSINFO();
 wxTimerEvent *wxTimerEvent_new(wxTimer * timer);
 int wxTimerEvent_GetInterval(const wxTimerEvent * self);
 wxTimer * wxTimerEvent_GetTimer(const wxTimerEvent * self);

--- a/wx-base/src/generated.cpp
+++ b/wx-base/src/generated.cpp
@@ -214,6 +214,9 @@ wxDateTime *wxDateTime_UNow() {
 }
 
 // CLASS: wxEvent
+wxClassInfo *wxEvent_CLASSINFO() {
+    return wxCLASSINFO(wxEvent);
+}
 wxEvent * wxEvent_Clone(const wxEvent * self) {
     return self->Clone();
 }
@@ -258,6 +261,9 @@ int wxEvent_StopPropagation(wxEvent * self) {
 }
 
 // CLASS: wxEvtHandler
+wxClassInfo *wxEvtHandler_CLASSINFO() {
+    return wxCLASSINFO(wxEvtHandler);
+}
 void wxEvtHandler_QueueEvent(wxEvtHandler * self, wxEvent * event) {
     return self->QueueEvent(event);
 }
@@ -542,6 +548,9 @@ wxString *wxFileName_StripExtension(const wxString * fullname) {
 }
 
 // CLASS: wxObject
+wxClassInfo *wxObject_CLASSINFO() {
+    return wxCLASSINFO(wxObject);
+}
 wxObject *wxObject_new() {
     return new wxObject();
 }
@@ -649,6 +658,9 @@ wxString *wxStandardPaths_MSWGetShellDir(int csidl) {
 #endif
 
 // CLASS: wxTimer
+wxClassInfo *wxTimer_CLASSINFO() {
+    return wxCLASSINFO(wxTimer);
+}
 wxTimer *wxTimer_new() {
     return new wxTimer();
 }
@@ -687,6 +699,9 @@ void wxTimer_Stop(wxTimer * self) {
 }
 
 // CLASS: wxTimerEvent
+wxClassInfo *wxTimerEvent_CLASSINFO() {
+    return wxCLASSINFO(wxTimerEvent);
+}
 wxTimerEvent *wxTimerEvent_new(wxTimer * timer) {
     return new wxTimerEvent(*timer);
 }

--- a/wx-base/src/generated.rs
+++ b/wx-base/src/generated.rs
@@ -190,6 +190,11 @@ impl<const OWNED: bool> EventIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> From<EventIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
+    fn from(o: EventIsOwned<OWNED>) -> Self {
+        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
 impl<const OWNED: bool> DynamicCast for EventIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxEvent_CLASSINFO()) }
@@ -215,6 +220,11 @@ impl<const OWNED: bool> EvtHandlerIsOwned<OWNED> {
     }
     pub fn none() -> Option<&'static Self> {
         None
+    }
+}
+impl<const OWNED: bool> From<EvtHandlerIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
+    fn from(o: EvtHandlerIsOwned<OWNED>) -> Self {
+        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for EvtHandlerIsOwned<OWNED> {
@@ -352,6 +362,16 @@ impl<const OWNED: bool> TimerIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> From<TimerIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
+    fn from(o: TimerIsOwned<OWNED>) -> Self {
+        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<TimerIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
+    fn from(o: TimerIsOwned<OWNED>) -> Self {
+        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
 impl<const OWNED: bool> DynamicCast for TimerIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxTimer_CLASSINFO()) }
@@ -374,6 +394,16 @@ impl<const OWNED: bool> TimerEventIsOwned<OWNED> {
     }
     pub fn none() -> Option<&'static Self> {
         None
+    }
+}
+impl<const OWNED: bool> From<TimerEventIsOwned<OWNED>> for EventIsOwned<OWNED> {
+    fn from(o: TimerEventIsOwned<OWNED>) -> Self {
+        unsafe { EventIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<TimerEventIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
+    fn from(o: TimerEventIsOwned<OWNED>) -> Self {
+        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for TimerEventIsOwned<OWNED> {

--- a/wx-base/src/generated.rs
+++ b/wx-base/src/generated.rs
@@ -190,7 +190,7 @@ impl<const OWNED: bool> EventIsOwned<OWNED> {
         None
     }
 }
-impl<const OWNED: bool> ClassInfoMacro for EventIsOwned<OWNED> {
+impl<const OWNED: bool> DynamicCast for EventIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxEvent_CLASSINFO()) }
     }
@@ -217,7 +217,7 @@ impl<const OWNED: bool> EvtHandlerIsOwned<OWNED> {
         None
     }
 }
-impl<const OWNED: bool> ClassInfoMacro for EvtHandlerIsOwned<OWNED> {
+impl<const OWNED: bool> DynamicCast for EvtHandlerIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxEvtHandler_CLASSINFO()) }
     }
@@ -273,7 +273,7 @@ impl<const OWNED: bool> ObjectIsOwned<OWNED> {
         None
     }
 }
-impl<const OWNED: bool> ClassInfoMacro for ObjectIsOwned<OWNED> {
+impl<const OWNED: bool> DynamicCast for ObjectIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxObject_CLASSINFO()) }
     }
@@ -352,7 +352,7 @@ impl<const OWNED: bool> TimerIsOwned<OWNED> {
         None
     }
 }
-impl<const OWNED: bool> ClassInfoMacro for TimerIsOwned<OWNED> {
+impl<const OWNED: bool> DynamicCast for TimerIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxTimer_CLASSINFO()) }
     }
@@ -376,7 +376,7 @@ impl<const OWNED: bool> TimerEventIsOwned<OWNED> {
         None
     }
 }
-impl<const OWNED: bool> ClassInfoMacro for TimerEventIsOwned<OWNED> {
+impl<const OWNED: bool> DynamicCast for TimerEventIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxTimerEvent_CLASSINFO()) }
     }

--- a/wx-base/src/generated.rs
+++ b/wx-base/src/generated.rs
@@ -192,7 +192,7 @@ impl<const OWNED: bool> EventIsOwned<OWNED> {
 }
 impl<const OWNED: bool> From<EventIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
     fn from(o: EventIsOwned<OWNED>) -> Self {
-        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for EventIsOwned<OWNED> {
@@ -224,7 +224,7 @@ impl<const OWNED: bool> EvtHandlerIsOwned<OWNED> {
 }
 impl<const OWNED: bool> From<EvtHandlerIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
     fn from(o: EvtHandlerIsOwned<OWNED>) -> Self {
-        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for EvtHandlerIsOwned<OWNED> {
@@ -364,12 +364,12 @@ impl<const OWNED: bool> TimerIsOwned<OWNED> {
 }
 impl<const OWNED: bool> From<TimerIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
     fn from(o: TimerIsOwned<OWNED>) -> Self {
-        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<TimerIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
     fn from(o: TimerIsOwned<OWNED>) -> Self {
-        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for TimerIsOwned<OWNED> {
@@ -398,12 +398,12 @@ impl<const OWNED: bool> TimerEventIsOwned<OWNED> {
 }
 impl<const OWNED: bool> From<TimerEventIsOwned<OWNED>> for EventIsOwned<OWNED> {
     fn from(o: TimerEventIsOwned<OWNED>) -> Self {
-        unsafe { EventIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<TimerEventIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
     fn from(o: TimerEventIsOwned<OWNED>) -> Self {
-        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for TimerEventIsOwned<OWNED> {

--- a/wx-base/src/generated.rs
+++ b/wx-base/src/generated.rs
@@ -190,6 +190,11 @@ impl<const OWNED: bool> EventIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> ClassInfoMacro for EventIsOwned<OWNED> {
+    fn class_info() -> ClassInfoIsOwned<false> {
+        unsafe { ClassInfoIsOwned::from_ptr(ffi::wxEvent_CLASSINFO()) }
+    }
+}
 impl<const OWNED: bool> Drop for EventIsOwned<OWNED> {
     fn drop(&mut self) {
         if OWNED {
@@ -210,6 +215,11 @@ impl<const OWNED: bool> EvtHandlerIsOwned<OWNED> {
     }
     pub fn none() -> Option<&'static Self> {
         None
+    }
+}
+impl<const OWNED: bool> ClassInfoMacro for EvtHandlerIsOwned<OWNED> {
+    fn class_info() -> ClassInfoIsOwned<false> {
+        unsafe { ClassInfoIsOwned::from_ptr(ffi::wxEvtHandler_CLASSINFO()) }
     }
 }
 
@@ -261,6 +271,11 @@ impl<const OWNED: bool> ObjectIsOwned<OWNED> {
     }
     pub fn none() -> Option<&'static Self> {
         None
+    }
+}
+impl<const OWNED: bool> ClassInfoMacro for ObjectIsOwned<OWNED> {
+    fn class_info() -> ClassInfoIsOwned<false> {
+        unsafe { ClassInfoIsOwned::from_ptr(ffi::wxObject_CLASSINFO()) }
     }
 }
 impl<const OWNED: bool> Drop for ObjectIsOwned<OWNED> {
@@ -337,6 +352,11 @@ impl<const OWNED: bool> TimerIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> ClassInfoMacro for TimerIsOwned<OWNED> {
+    fn class_info() -> ClassInfoIsOwned<false> {
+        unsafe { ClassInfoIsOwned::from_ptr(ffi::wxTimer_CLASSINFO()) }
+    }
+}
 
 // wxTimerEvent
 wx_class! { TimerEvent =
@@ -354,6 +374,11 @@ impl<const OWNED: bool> TimerEventIsOwned<OWNED> {
     }
     pub fn none() -> Option<&'static Self> {
         None
+    }
+}
+impl<const OWNED: bool> ClassInfoMacro for TimerEventIsOwned<OWNED> {
+    fn class_info() -> ClassInfoIsOwned<false> {
+        unsafe { ClassInfoIsOwned::from_ptr(ffi::wxTimerEvent_CLASSINFO()) }
     }
 }
 impl<const OWNED: bool> Drop for TimerEventIsOwned<OWNED> {

--- a/wx-base/src/generated/ffi.rs
+++ b/wx-base/src/generated/ffi.rs
@@ -206,6 +206,7 @@ extern "C" {
     pub fn wxDateTime_UNow() -> *mut c_void;
 
     // wxEvent
+    pub fn wxEvent_CLASSINFO() -> *mut c_void;
     // NOT_SUPPORTED: pub fn wxEvent_new(id: c_int, event_type: wxEventType) -> *mut c_void;
     pub fn wxEvent_Clone(self_: *const c_void) -> *mut c_void;
     pub fn wxEvent_GetEventObject(self_: *const c_void) -> *mut c_void;
@@ -226,6 +227,7 @@ extern "C" {
     pub fn wxEvent_StopPropagation(self_: *mut c_void) -> c_int;
 
     // wxEvtHandler
+    pub fn wxEvtHandler_CLASSINFO() -> *mut c_void;
     pub fn wxEvtHandler_QueueEvent(self_: *mut c_void, event: *mut c_void);
     pub fn wxEvtHandler_AddPendingEvent(self_: *mut c_void, event: *const c_void);
     // NOT_SUPPORTED: pub fn wxEvtHandler_CallAfter(self_: *mut c_void, method: *mut c_void, x1: T1, None: ...);
@@ -410,6 +412,7 @@ extern "C" {
     pub fn wxFileName_StripExtension(fullname: *const c_void) -> *mut c_void;
 
     // wxObject
+    pub fn wxObject_CLASSINFO() -> *mut c_void;
     pub fn wxObject_new() -> *mut c_void;
     pub fn wxObject_new1(other: *const c_void) -> *mut c_void;
     // DTOR: pub fn wxObject_~wxObject(self_: *mut c_void);
@@ -453,6 +456,7 @@ extern "C" {
     pub fn wxStandardPaths_MSWGetShellDir(csidl: c_int) -> *mut c_void;
 
     // wxTimer
+    pub fn wxTimer_CLASSINFO() -> *mut c_void;
     pub fn wxTimer_new() -> *mut c_void;
     pub fn wxTimer_new1(owner: *mut c_void, id: c_int) -> *mut c_void;
     // DTOR: pub fn wxTimer_~wxTimer(self_: *mut c_void);
@@ -468,6 +472,7 @@ extern "C" {
     pub fn wxTimer_Stop(self_: *mut c_void);
 
     // wxTimerEvent
+    pub fn wxTimerEvent_CLASSINFO() -> *mut c_void;
     pub fn wxTimerEvent_new(timer: *mut c_void) -> *mut c_void;
     pub fn wxTimerEvent_GetInterval(self_: *const c_void) -> c_int;
     pub fn wxTimerEvent_GetTimer(self_: *const c_void) -> *mut c_void;

--- a/wx-base/src/lib.rs
+++ b/wx-base/src/lib.rs
@@ -125,9 +125,9 @@ pub mod methods {
         }
     }
 
-    pub trait ClassInfoMacro: ObjectMethods {
+    pub trait DynamicCast: ObjectMethods {
         fn class_info() -> ClassInfoIsOwned<false>;
-        fn as_unowned<T: ClassInfoMacro>(&self) -> Option<T::Unowned> {
+        fn as_unowned<T: DynamicCast>(&self) -> Option<T::Unowned> {
             if self.is_kind_of(Some(&T::class_info())) {
                 unsafe { Some(T::from_unowned_ptr(self.as_ptr())) }
             } else {

--- a/wx-base/src/lib.rs
+++ b/wx-base/src/lib.rs
@@ -124,6 +124,10 @@ pub mod methods {
             }
         }
     }
+
+    pub trait ClassInfoMacro: ObjectMethods {
+        fn class_info() -> ClassInfoIsOwned<false>;
+    }
 }
 
 // wxString

--- a/wx-base/src/lib.rs
+++ b/wx-base/src/lib.rs
@@ -127,6 +127,13 @@ pub mod methods {
 
     pub trait ClassInfoMacro: ObjectMethods {
         fn class_info() -> ClassInfoIsOwned<false>;
+        fn as_unowned<T: ClassInfoMacro>(&self) -> Option<T::Unowned> {
+            if self.is_kind_of(Some(&T::class_info())) {
+                unsafe { Some(T::from_unowned_ptr(self.as_ptr())) }
+            } else {
+                None
+            }
+        }
     }
 }
 

--- a/wx-core/include/generated.h
+++ b/wx-core/include/generated.h
@@ -22,6 +22,7 @@ typedef wxBitmap wxBitmapBundle;
 extern "C" {
 
 // CLASS: wxAnyButton
+wxClassInfo *wxAnyButton_CLASSINFO();
 wxAnyButton *wxAnyButton_new();
 wxBitmap *wxAnyButton_GetBitmap(const wxAnyButton * self);
 wxBitmap *wxAnyButton_GetBitmapCurrent(const wxAnyButton * self);
@@ -41,6 +42,7 @@ void wxAnyButton_SetBitmapMargins1(wxAnyButton * self, const wxSize * sz);
 void wxAnyButton_SetBitmapPosition(wxAnyButton * self, wxDirection dir);
 
 // CLASS: wxArtProvider
+wxClassInfo *wxArtProvider_CLASSINFO();
 bool wxArtProvider_Delete(wxArtProvider * provider);
 wxBitmap *wxArtProvider_GetBitmap(const wxArtID * id, const wxArtClient * client, const wxSize * size);
 #if wxCHECK_VERSION(3, 1, 0)
@@ -64,6 +66,7 @@ wxArtID *wxArtProvider_GetMessageBoxIconId(int flags);
 wxIcon *wxArtProvider_GetMessageBoxIcon(int flags);
 
 // CLASS: wxBitmap
+wxClassInfo *wxBitmap_CLASSINFO();
 wxBitmap *wxBitmap_new();
 wxBitmap *wxBitmap_new1(const wxBitmap * bitmap);
 wxBitmap *wxBitmap_new3(int width, int height, int depth);
@@ -180,6 +183,7 @@ wxBitmapBundle *wxBitmapBundle_FromSVGResource(const wxString * name, const wxSi
 #endif
 
 // CLASS: wxBitmapButton
+wxClassInfo *wxBitmapButton_CLASSINFO();
 wxBitmapButton *wxBitmapButton_new();
 wxBitmapButton *wxBitmapButton_new1(wxWindow * parent, wxWindowID id, const wxBitmapBundle * bitmap, const wxPoint * pos, const wxSize * size, long style, const wxValidator * validator, const wxString * name);
 bool wxBitmapButton_Create(wxBitmapButton * self, wxWindow * parent, wxWindowID id, const wxBitmapBundle * bitmap, const wxPoint * pos, const wxSize * size, long style, const wxValidator * validator, const wxString * name);
@@ -189,6 +193,7 @@ wxBitmapButton * wxBitmapButton_NewCloseButton(wxWindow * parent, wxWindowID win
 #endif
 
 // CLASS: wxBookCtrlBase
+wxClassInfo *wxBookCtrlBase_CLASSINFO();
 int wxBookCtrlBase_GetPageImage(const wxBookCtrlBase * self, size_t n_page);
 bool wxBookCtrlBase_SetPageImage(wxBookCtrlBase * self, size_t page, int image);
 wxString *wxBookCtrlBase_GetPageText(const wxBookCtrlBase * self, size_t n_page);
@@ -211,17 +216,20 @@ wxWindow * wxBookCtrlBase_GetPage(const wxBookCtrlBase * self, size_t page);
 bool wxBookCtrlBase_Create(wxBookCtrlBase * self, wxWindow * parent, wxWindowID winid, const wxPoint * pos, const wxSize * size, long style, const wxString * name);
 
 // CLASS: wxBookCtrlEvent
+wxClassInfo *wxBookCtrlEvent_CLASSINFO();
 int wxBookCtrlEvent_GetOldSelection(const wxBookCtrlEvent * self);
 int wxBookCtrlEvent_GetSelection(const wxBookCtrlEvent * self);
 void wxBookCtrlEvent_SetOldSelection(wxBookCtrlEvent * self, int page);
 void wxBookCtrlEvent_SetSelection(wxBookCtrlEvent * self, int page);
 
 // CLASS: wxBoxSizer
+wxClassInfo *wxBoxSizer_CLASSINFO();
 wxBoxSizer *wxBoxSizer_new(int orient);
 int wxBoxSizer_GetOrientation(const wxBoxSizer * self);
 void wxBoxSizer_SetOrientation(wxBoxSizer * self, int orient);
 
 // CLASS: wxButton
+wxClassInfo *wxButton_CLASSINFO();
 wxButton *wxButton_new();
 wxButton *wxButton_new1(wxWindow * parent, wxWindowID id, const wxString * label, const wxPoint * pos, const wxSize * size, long style, const wxValidator * validator, const wxString * name);
 bool wxButton_Create(wxButton * self, wxWindow * parent, wxWindowID id, const wxString * label, const wxPoint * pos, const wxSize * size, long style, const wxValidator * validator, const wxString * name);
@@ -233,6 +241,7 @@ wxSize *wxButton_GetDefaultSize(wxWindow * win);
 #endif
 
 // CLASS: wxCheckBox
+wxClassInfo *wxCheckBox_CLASSINFO();
 wxCheckBox *wxCheckBox_new();
 wxCheckBox *wxCheckBox_new1(wxWindow * parent, wxWindowID id, const wxString * label, const wxPoint * pos, const wxSize * size, long style, const wxValidator * validator, const wxString * name);
 bool wxCheckBox_Create(wxCheckBox * self, wxWindow * parent, wxWindowID id, const wxString * label, const wxPoint * pos, const wxSize * size, long style, const wxValidator * validator, const wxString * name);
@@ -245,6 +254,7 @@ void wxCheckBox_SetValue(wxCheckBox * self, bool state);
 void wxCheckBox_Set3StateValue(wxCheckBox * self, wxCheckBoxState state);
 
 // CLASS: wxCheckListBox
+wxClassInfo *wxCheckListBox_CLASSINFO();
 wxCheckListBox *wxCheckListBox_new();
 wxCheckListBox *wxCheckListBox_new2(wxWindow * parent, wxWindowID id, const wxPoint * pos, const wxSize * size, const wxArrayString * choices, long style, const wxValidator * validator, const wxString * name);
 bool wxCheckListBox_Create1(wxCheckListBox * self, wxWindow * parent, wxWindowID id, const wxPoint * pos, const wxSize * size, const wxArrayString * choices, long style, const wxValidator * validator, const wxString * name);
@@ -255,6 +265,7 @@ unsigned int wxCheckListBox_GetCheckedItems(const wxCheckListBox * self, wxArray
 wxItemContainer *wxCheckListBox_AsItemContainer(wxCheckListBox* obj);
 
 // CLASS: wxChoice
+wxClassInfo *wxChoice_CLASSINFO();
 wxChoice *wxChoice_new();
 wxChoice *wxChoice_new2(wxWindow * parent, wxWindowID id, const wxPoint * pos, const wxSize * size, const wxArrayString * choices, long style, const wxValidator * validator, const wxString * name);
 bool wxChoice_Create1(wxChoice * self, wxWindow * parent, wxWindowID id, const wxPoint * pos, const wxSize * size, const wxArrayString * choices, long style, const wxValidator * validator, const wxString * name);
@@ -266,6 +277,7 @@ bool wxChoice_IsSorted(const wxChoice * self);
 wxItemContainer *wxChoice_AsItemContainer(wxChoice* obj);
 
 // CLASS: wxColour
+wxClassInfo *wxColour_CLASSINFO();
 wxColour *wxColour_new();
 wxColour *wxColour_new2(const wxString * colour_name);
 wxColour *wxColour_new4(const wxColour * colour);
@@ -290,6 +302,7 @@ void wxColour_MakeGrey1(unsigned char * r, unsigned char * g, unsigned char * b,
 void wxColour_ChangeLightness1(unsigned char * r, unsigned char * g, unsigned char * b, int ialpha);
 
 // CLASS: wxColourPickerCtrl
+wxClassInfo *wxColourPickerCtrl_CLASSINFO();
 wxColourPickerCtrl *wxColourPickerCtrl_new();
 wxColourPickerCtrl *wxColourPickerCtrl_new1(wxWindow * parent, wxWindowID id, const wxColour * colour, const wxPoint * pos, const wxSize * size, long style, const wxValidator * validator, const wxString * name);
 bool wxColourPickerCtrl_Create(wxColourPickerCtrl * self, wxWindow * parent, wxWindowID id, const wxColour * colour, const wxPoint * pos, const wxSize * size, long style, const wxValidator * validator, const wxString * name);
@@ -297,6 +310,7 @@ wxColour *wxColourPickerCtrl_GetColour(const wxColourPickerCtrl * self);
 void wxColourPickerCtrl_SetColour(wxColourPickerCtrl * self, const wxColour * col);
 
 // CLASS: wxComboBox
+wxClassInfo *wxComboBox_CLASSINFO();
 wxComboBox *wxComboBox_new();
 wxComboBox *wxComboBox_new2(wxWindow * parent, wxWindowID id, const wxString * value, const wxPoint * pos, const wxSize * size, const wxArrayString * choices, long style, const wxValidator * validator, const wxString * name);
 bool wxComboBox_Create1(wxComboBox * self, wxWindow * parent, wxWindowID id, const wxString * value, const wxPoint * pos, const wxSize * size, const wxArrayString * choices, long style, const wxValidator * validator, const wxString * name);
@@ -310,6 +324,7 @@ wxItemContainer *wxComboBox_AsItemContainer(wxComboBox* obj);
 wxTextEntry *wxComboBox_AsTextEntry(wxComboBox* obj);
 
 // CLASS: wxCommandEvent
+wxClassInfo *wxCommandEvent_CLASSINFO();
 void * wxCommandEvent_GetClientData(const wxCommandEvent * self);
 wxClientData * wxCommandEvent_GetClientObject(const wxCommandEvent * self);
 long wxCommandEvent_GetExtraLong(const wxCommandEvent * self);
@@ -325,6 +340,7 @@ void wxCommandEvent_SetInt(wxCommandEvent * self, int int_command);
 void wxCommandEvent_SetString(wxCommandEvent * self, const wxString * string);
 
 // CLASS: wxControl
+wxClassInfo *wxControl_CLASSINFO();
 wxControl *wxControl_new(wxWindow * parent, wxWindowID id, const wxPoint * pos, const wxSize * size, long style, const wxValidator * validator, const wxString * name);
 wxControl *wxControl_new1();
 bool wxControl_Create(wxControl * self, wxWindow * parent, wxWindowID id, const wxPoint * pos, const wxSize * size, long style, const wxValidator * validator, const wxString * name);
@@ -343,6 +359,7 @@ wxString *wxControl_EscapeMnemonics(const wxString * text);
 wxString *wxControl_Ellipsize(const wxString * label, const wxDC * dc, wxEllipsizeMode mode, int max_width, int flags);
 
 // CLASS: wxDatePickerCtrl
+wxClassInfo *wxDatePickerCtrl_CLASSINFO();
 wxDatePickerCtrl *wxDatePickerCtrl_new();
 wxDatePickerCtrl *wxDatePickerCtrl_new1(wxWindow * parent, wxWindowID id, const wxDateTime * dt, const wxPoint * pos, const wxSize * size, long style, const wxValidator * validator, const wxString * name);
 bool wxDatePickerCtrl_Create(wxDatePickerCtrl * self, wxWindow * parent, wxWindowID id, const wxDateTime * dt, const wxPoint * pos, const wxSize * size, long style, const wxValidator * validator, const wxString * name);
@@ -355,6 +372,7 @@ void wxDatePickerCtrl_SetRange(wxDatePickerCtrl * self, const wxDateTime * dt1, 
 void wxDatePickerCtrl_SetValue(wxDatePickerCtrl * self, const wxDateTime * dt);
 
 // CLASS: wxDirPickerCtrl
+wxClassInfo *wxDirPickerCtrl_CLASSINFO();
 wxDirPickerCtrl *wxDirPickerCtrl_new();
 wxDirPickerCtrl *wxDirPickerCtrl_new1(wxWindow * parent, wxWindowID id, const wxString * path, const wxString * message, const wxPoint * pos, const wxSize * size, long style, const wxValidator * validator, const wxString * name);
 bool wxDirPickerCtrl_Create(wxDirPickerCtrl * self, wxWindow * parent, wxWindowID id, const wxString * path, const wxString * message, const wxPoint * pos, const wxSize * size, long style, const wxValidator * validator, const wxString * name);
@@ -365,6 +383,7 @@ void wxDirPickerCtrl_SetInitialDirectory(wxDirPickerCtrl * self, const wxString 
 void wxDirPickerCtrl_SetPath(wxDirPickerCtrl * self, const wxString * dirname);
 
 // CLASS: wxEditableListBox
+wxClassInfo *wxEditableListBox_CLASSINFO();
 wxEditableListBox *wxEditableListBox_new();
 wxEditableListBox *wxEditableListBox_new1(wxWindow * parent, wxWindowID id, const wxString * label, const wxPoint * pos, const wxSize * size, long style, const wxString * name);
 bool wxEditableListBox_Create(wxEditableListBox * self, wxWindow * parent, wxWindowID id, const wxString * label, const wxPoint * pos, const wxSize * size, long style, const wxString * name);
@@ -372,6 +391,7 @@ void wxEditableListBox_SetStrings(wxEditableListBox * self, const wxArrayString 
 void wxEditableListBox_GetStrings(const wxEditableListBox * self, wxArrayString * strings);
 
 // CLASS: wxFileCtrl
+wxClassInfo *wxFileCtrl_CLASSINFO();
 wxFileCtrl *wxFileCtrl_new();
 wxFileCtrl *wxFileCtrl_new1(wxWindow * parent, wxWindowID id, const wxString * default_directory, const wxString * default_filename, const wxString * wild_card, long style, const wxPoint * pos, const wxSize * size, const wxString * name);
 bool wxFileCtrl_Create(wxFileCtrl * self, wxWindow * parent, wxWindowID id, const wxString * default_directory, const wxString * default_filename, const wxString * wild_card, long style, const wxPoint * pos, const wxSize * size, const wxString * name);
@@ -390,6 +410,7 @@ void wxFileCtrl_SetWildcard(wxFileCtrl * self, const wxString * wild_card);
 void wxFileCtrl_ShowHidden(wxFileCtrl * self, bool show);
 
 // CLASS: wxFont
+wxClassInfo *wxFont_CLASSINFO();
 #if wxCHECK_VERSION(3, 1, 0)
 wxFont *wxFont_GetBaseFont(const wxFont * self);
 #endif
@@ -447,6 +468,7 @@ wxFont *wxFont_new5(const wxString * native_info_string);
 wxFont *wxFont_new6(const wxNativeFontInfo * native_info);
 
 // CLASS: wxFontPickerCtrl
+wxClassInfo *wxFontPickerCtrl_CLASSINFO();
 wxFontPickerCtrl *wxFontPickerCtrl_new();
 wxFontPickerCtrl *wxFontPickerCtrl_new1(wxWindow * parent, wxWindowID id, const wxFont * font, const wxPoint * pos, const wxSize * size, long style, const wxValidator * validator, const wxString * name);
 bool wxFontPickerCtrl_Create(wxFontPickerCtrl * self, wxWindow * parent, wxWindowID id, const wxFont * font, const wxPoint * pos, const wxSize * size, long style, const wxValidator * validator, const wxString * name);
@@ -464,6 +486,7 @@ void wxFontPickerCtrl_SetSelectedColour(wxFontPickerCtrl * self, const wxColour 
 void wxFontPickerCtrl_SetSelectedFont(wxFontPickerCtrl * self, const wxFont * font);
 
 // CLASS: wxFrame
+wxClassInfo *wxFrame_CLASSINFO();
 wxFrame *wxFrame_new();
 wxFrame *wxFrame_new1(wxWindow * parent, wxWindowID id, const wxString * title, const wxPoint * pos, const wxSize * size, long style, const wxString * name);
 void wxFrame_Centre(wxFrame * self, int direction);
@@ -491,8 +514,10 @@ void wxFrame_PushStatusText(wxFrame * self, const wxString * text, int number);
 void wxFrame_PopStatusText(wxFrame * self, int number);
 
 // CLASS: wxGDIObject
+wxClassInfo *wxGDIObject_CLASSINFO();
 
 // CLASS: wxGauge
+wxClassInfo *wxGauge_CLASSINFO();
 wxGauge *wxGauge_new();
 wxGauge *wxGauge_new1(wxWindow * parent, wxWindowID id, int range, const wxPoint * pos, const wxSize * size, long style, const wxValidator * validator, const wxString * name);
 bool wxGauge_Create(wxGauge * self, wxWindow * parent, wxWindowID id, int range, const wxPoint * pos, const wxSize * size, long style, const wxValidator * validator, const wxString * name);
@@ -504,6 +529,7 @@ void wxGauge_SetRange(wxGauge * self, int range);
 void wxGauge_SetValue(wxGauge * self, int pos);
 
 // CLASS: wxGenericDirCtrl
+wxClassInfo *wxGenericDirCtrl_CLASSINFO();
 wxGenericDirCtrl *wxGenericDirCtrl_new();
 wxGenericDirCtrl *wxGenericDirCtrl_new1(wxWindow * parent, wxWindowID id, const wxString * dir, const wxPoint * pos, const wxSize * size, long style, const wxString * filter, int default_filter, const wxString * name);
 bool wxGenericDirCtrl_CollapsePath(wxGenericDirCtrl * self, const wxString * path);
@@ -556,6 +582,7 @@ wxHeaderColumnSimple *wxHeaderColumnSimple_new(const wxString * title, int width
 wxHeaderColumnSimple *wxHeaderColumnSimple_new1(const wxBitmapBundle * bitmap, int width, wxAlignment align, int flags);
 
 // CLASS: wxHeaderCtrl
+wxClassInfo *wxHeaderCtrl_CLASSINFO();
 bool wxHeaderCtrl_Create(wxHeaderCtrl * self, wxWindow * parent, wxWindowID winid, const wxPoint * pos, const wxSize * size, long style, const wxString * name);
 void wxHeaderCtrl_SetColumnCount(wxHeaderCtrl * self, unsigned int count);
 unsigned int wxHeaderCtrl_GetColumnCount(const wxHeaderCtrl * self);
@@ -576,6 +603,7 @@ int wxHeaderCtrl_GetColumnTitleWidth1(wxHeaderCtrl * self, unsigned int idx);
 void wxHeaderCtrl_MoveColumnInOrderArray(wxArrayInt * order, unsigned int idx, unsigned int pos);
 
 // CLASS: wxHeaderCtrlSimple
+wxClassInfo *wxHeaderCtrlSimple_CLASSINFO();
 wxHeaderCtrlSimple *wxHeaderCtrlSimple_new();
 wxHeaderCtrlSimple *wxHeaderCtrlSimple_new1(wxWindow * parent, wxWindowID winid, const wxPoint * pos, const wxSize * size, long style, const wxString * name);
 void wxHeaderCtrlSimple_InsertColumn(wxHeaderCtrlSimple * self, const wxHeaderColumnSimple * col, unsigned int idx);
@@ -587,6 +615,7 @@ void wxHeaderCtrlSimple_ShowSortIndicator(wxHeaderCtrlSimple * self, unsigned in
 void wxHeaderCtrlSimple_RemoveSortIndicator(wxHeaderCtrlSimple * self);
 
 // CLASS: wxHyperlinkCtrl
+wxClassInfo *wxHyperlinkCtrl_CLASSINFO();
 wxHyperlinkCtrl *wxHyperlinkCtrl_new();
 wxHyperlinkCtrl *wxHyperlinkCtrl_new1(wxWindow * parent, wxWindowID id, const wxString * label, const wxString * url, const wxPoint * pos, const wxSize * size, long style, const wxString * name);
 bool wxHyperlinkCtrl_Create(wxHyperlinkCtrl * self, wxWindow * parent, wxWindowID id, const wxString * label, const wxString * url, const wxPoint * pos, const wxSize * size, long style, const wxString * name);
@@ -602,6 +631,7 @@ void wxHyperlinkCtrl_SetVisited(wxHyperlinkCtrl * self, bool visited);
 void wxHyperlinkCtrl_SetVisitedColour(wxHyperlinkCtrl * self, const wxColour * colour);
 
 // CLASS: wxIcon
+wxClassInfo *wxIcon_CLASSINFO();
 wxIcon *wxIcon_new();
 wxIcon *wxIcon_new1(const wxIcon * icon);
 wxIcon *wxIcon_new3(const char *const * bits);
@@ -676,6 +706,7 @@ void wxItemContainerImmutable_SetString(wxItemContainerImmutable * self, unsigne
 int wxItemContainerImmutable_FindString(const wxItemContainerImmutable * self, const wxString * string, bool case_sensitive);
 
 // CLASS: wxListBox
+wxClassInfo *wxListBox_CLASSINFO();
 wxListBox *wxListBox_new();
 wxListBox *wxListBox_new2(wxWindow * parent, wxWindowID id, const wxPoint * pos, const wxSize * size, const wxArrayString * choices, long style, const wxValidator * validator, const wxString * name);
 bool wxListBox_Create1(wxListBox * self, wxWindow * parent, wxWindowID id, const wxPoint * pos, const wxSize * size, const wxArrayString * choices, long style, const wxValidator * validator, const wxString * name);
@@ -699,6 +730,7 @@ int wxListBox_GetTopItem(const wxListBox * self);
 wxItemContainer *wxListBox_AsItemContainer(wxListBox* obj);
 
 // CLASS: wxMenu
+wxClassInfo *wxMenu_CLASSINFO();
 wxMenu *wxMenu_new();
 wxMenu *wxMenu_new1(long style);
 wxMenu *wxMenu_new2(const wxString * title, long style);
@@ -756,6 +788,7 @@ void wxMenu_Detach(wxMenu * self);
 bool wxMenu_IsAttached(const wxMenu * self);
 
 // CLASS: wxMenuBar
+wxClassInfo *wxMenuBar_CLASSINFO();
 wxMenuBar *wxMenuBar_new(long style);
 bool wxMenuBar_Append(wxMenuBar * self, wxMenu * menu, const wxString * title);
 void wxMenuBar_Check(wxMenuBar * self, int id, bool check);
@@ -792,6 +825,7 @@ wxMenuBar * wxMenuBar_MacGetCommonMenuBar();
 #endif
 
 // CLASS: wxMenuItem
+wxClassInfo *wxMenuItem_CLASSINFO();
 wxBitmap *wxMenuItem_GetBitmap(const wxMenuItem * self);
 #ifdef __WXMSW__
 wxBitmap *wxMenuItem_GetBitmap1(const wxMenuItem * self, bool checked);
@@ -851,10 +885,12 @@ void wxMenuItem_Enable(wxMenuItem * self, bool enable);
 wxString *wxMenuItem_GetLabelText(const wxString * text);
 
 // CLASS: wxNonOwnedWindow
+wxClassInfo *wxNonOwnedWindow_CLASSINFO();
 bool wxNonOwnedWindow_SetShape(wxNonOwnedWindow * self, const wxRegion * region);
 bool wxNonOwnedWindow_SetShape1(wxNonOwnedWindow * self, const wxGraphicsPath * path);
 
 // CLASS: wxNotebook
+wxClassInfo *wxNotebook_CLASSINFO();
 wxNotebook *wxNotebook_new();
 wxNotebook *wxNotebook_new1(wxWindow * parent, wxWindowID id, const wxPoint * pos, const wxSize * size, long style, const wxString * name);
 int wxNotebook_GetRowCount(const wxNotebook * self);
@@ -862,11 +898,13 @@ wxColour *wxNotebook_GetThemeBackgroundColour(const wxNotebook * self);
 void wxNotebook_SetPadding(wxNotebook * self, const wxSize * padding);
 
 // CLASS: wxNotifyEvent
+wxClassInfo *wxNotifyEvent_CLASSINFO();
 void wxNotifyEvent_Allow(wxNotifyEvent * self);
 bool wxNotifyEvent_IsAllowed(const wxNotifyEvent * self);
 void wxNotifyEvent_Veto(wxNotifyEvent * self);
 
 // CLASS: wxPanel
+wxClassInfo *wxPanel_CLASSINFO();
 wxPanel *wxPanel_new();
 wxPanel *wxPanel_new1(wxWindow * parent, wxWindowID id, const wxPoint * pos, const wxSize * size, long style, const wxString * name);
 bool wxPanel_Create(wxPanel * self, wxWindow * parent, wxWindowID id, const wxPoint * pos, const wxSize * size, long style, const wxString * name);
@@ -874,6 +912,7 @@ void wxPanel_OnSysColourChanged(wxPanel * self, wxSysColourChangedEvent * event)
 void wxPanel_SetFocusIgnoringChildren(wxPanel * self);
 
 // CLASS: wxPickerBase
+wxClassInfo *wxPickerBase_CLASSINFO();
 bool wxPickerBase_CreateBase(wxPickerBase * self, wxWindow * parent, wxWindowID id, const wxString * text, const wxPoint * pos, const wxSize * size, long style, const wxValidator * validator, const wxString * name);
 int wxPickerBase_GetInternalMargin(const wxPickerBase * self);
 int wxPickerBase_GetPickerCtrlProportion(const wxPickerBase * self);
@@ -902,6 +941,7 @@ wxPoint *wxPoint_new1(int x, int y);
 wxPoint *wxPoint_new2(const wxRealPoint * pt);
 
 // CLASS: wxRadioBox
+wxClassInfo *wxRadioBox_CLASSINFO();
 wxRadioBox *wxRadioBox_new();
 wxRadioBox *wxRadioBox_new2(wxWindow * parent, wxWindowID id, const wxString * label, const wxPoint * pos, const wxSize * size, const wxArrayString * choices, int major_dimension, long style, const wxValidator * validator, const wxString * name);
 bool wxRadioBox_Create1(wxRadioBox * self, wxWindow * parent, wxWindowID id, const wxString * label, const wxPoint * pos, const wxSize * size, const wxArrayString * choices, int major_dimension, long style, const wxValidator * validator, const wxString * name);
@@ -1014,6 +1054,7 @@ void wxSize_SetHeight(wxSize * self, int height);
 void wxSize_SetWidth(wxSize * self, int width);
 
 // CLASS: wxSizer
+wxClassInfo *wxSizer_CLASSINFO();
 wxSizerItem * wxSizer_Add(wxSizer * self, wxWindow * window, const wxSizerFlags * flags);
 wxSizerItem * wxSizer_Add1(wxSizer * self, wxWindow * window, int proportion, int flag, int border, wxObject * user_data);
 wxSizerItem * wxSizer_Add2(wxSizer * self, wxSizer * sizer, const wxSizerFlags * flags);
@@ -1126,6 +1167,7 @@ void wxSizerFlags_DisableConsistencyChecks();
 int wxSizerFlags_GetDefaultBorder();
 
 // CLASS: wxStaticBitmap
+wxClassInfo *wxStaticBitmap_CLASSINFO();
 wxStaticBitmap *wxStaticBitmap_new();
 wxStaticBitmap *wxStaticBitmap_new1(wxWindow * parent, wxWindowID id, const wxBitmapBundle * label, const wxPoint * pos, const wxSize * size, long style, const wxString * name);
 bool wxStaticBitmap_Create(wxStaticBitmap * self, wxWindow * parent, wxWindowID id, const wxBitmapBundle * label, const wxPoint * pos, const wxSize * size, long style, const wxString * name);
@@ -1135,16 +1177,19 @@ void wxStaticBitmap_SetBitmap(wxStaticBitmap * self, const wxBitmapBundle * labe
 void wxStaticBitmap_SetIcon(wxStaticBitmap * self, const wxIcon * label);
 
 // CLASS: wxStaticBox
+wxClassInfo *wxStaticBox_CLASSINFO();
 wxStaticBox *wxStaticBox_new();
 wxStaticBox *wxStaticBox_new1(wxWindow * parent, wxWindowID id, const wxString * label, const wxPoint * pos, const wxSize * size, long style, const wxString * name);
 bool wxStaticBox_Create(wxStaticBox * self, wxWindow * parent, wxWindowID id, const wxString * label, const wxPoint * pos, const wxSize * size, long style, const wxString * name);
 
 // CLASS: wxStaticBoxSizer
+wxClassInfo *wxStaticBoxSizer_CLASSINFO();
 wxStaticBoxSizer *wxStaticBoxSizer_new(wxStaticBox * box_, int orient);
 wxStaticBoxSizer *wxStaticBoxSizer_new1(int orient, wxWindow * parent, const wxString * label);
 wxStaticBox * wxStaticBoxSizer_GetStaticBox(const wxStaticBoxSizer * self);
 
 // CLASS: wxStaticText
+wxClassInfo *wxStaticText_CLASSINFO();
 wxStaticText *wxStaticText_new();
 wxStaticText *wxStaticText_new1(wxWindow * parent, wxWindowID id, const wxString * label, const wxPoint * pos, const wxSize * size, long style, const wxString * name);
 bool wxStaticText_Create(wxStaticText * self, wxWindow * parent, wxWindowID id, const wxString * label, const wxPoint * pos, const wxSize * size, long style, const wxString * name);
@@ -1253,6 +1298,7 @@ bool wxTextAttr_EqPartial(const wxTextAttr * self, const wxTextAttr * attr, bool
 wxTextAttr *wxTextAttr_Merge1(const wxTextAttr * base, const wxTextAttr * overlay);
 
 // CLASS: wxTextCtrl
+wxClassInfo *wxTextCtrl_CLASSINFO();
 #ifdef __WXOSX__
 void wxTextCtrl_OSXEnableNewLineReplacement(wxTextCtrl * self, bool enable);
 #endif
@@ -1335,6 +1381,7 @@ void wxTextEntry_Undo(wxTextEntry * self);
 void wxTextEntry_WriteText(wxTextEntry * self, const wxString * text);
 
 // CLASS: wxToolBar
+wxClassInfo *wxToolBar_CLASSINFO();
 wxToolBar *wxToolBar_new();
 wxToolBar *wxToolBar_new1(wxWindow * parent, wxWindowID id, const wxPoint * pos, const wxSize * size, long style, const wxString * name);
 wxToolBarToolBase * wxToolBar_AddCheckTool(wxToolBar * self, int tool_id, const wxString * label, const wxBitmapBundle * bitmap1, const wxBitmapBundle * bmp_disabled, const wxString * short_help, const wxString * long_help, wxObject * client_data);
@@ -1392,6 +1439,7 @@ wxToolBarToolBase * wxToolBar_CreateTool1(wxToolBar * self, wxControl * control,
 wxToolBarToolBase * wxToolBar_CreateSeparator(wxToolBar * self);
 
 // CLASS: wxTopLevelWindow
+wxClassInfo *wxTopLevelWindow_CLASSINFO();
 wxTopLevelWindow *wxTopLevelWindow_new();
 wxTopLevelWindow *wxTopLevelWindow_new1(wxWindow * parent, wxWindowID id, const wxString * title, const wxPoint * pos, const wxSize * size, long style, const wxString * name);
 bool wxTopLevelWindow_Create(wxTopLevelWindow * self, wxWindow * parent, wxWindowID id, const wxString * title, const wxPoint * pos, const wxSize * size, long style, const wxString * name);
@@ -1435,6 +1483,7 @@ bool wxTopLevelWindow_ShowFullScreen(wxTopLevelWindow * self, bool show, long st
 wxSize *wxTopLevelWindow_GetDefaultSize();
 
 // CLASS: wxValidator
+wxClassInfo *wxValidator_CLASSINFO();
 wxValidator *wxValidator_new();
 wxObject * wxValidator_Clone(const wxValidator * self);
 wxWindow * wxValidator_GetWindow(const wxValidator * self);
@@ -1446,6 +1495,7 @@ void wxValidator_SuppressBellOnError(bool suppress);
 bool wxValidator_IsSilent();
 
 // CLASS: wxWindow
+wxClassInfo *wxWindow_CLASSINFO();
 bool wxWindow_AcceptsFocus(const wxWindow * self);
 bool wxWindow_AcceptsFocusFromKeyboard(const wxWindow * self);
 bool wxWindow_AcceptsFocusRecursively(const wxWindow * self);
@@ -1753,6 +1803,7 @@ wxWindow *wxWindow_new1(wxWindow * parent, wxWindowID id, const wxPoint * pos, c
 bool wxWindow_Create(wxWindow * self, wxWindow * parent, wxWindowID id, const wxPoint * pos, const wxSize * size, long style, const wxString * name);
 
 // CLASS: wxWrapSizer
+wxClassInfo *wxWrapSizer_CLASSINFO();
 wxWrapSizer *wxWrapSizer_new(int orient, int flags);
 
 } // extern "C"

--- a/wx-core/include/manual.h
+++ b/wx-core/include/manual.h
@@ -15,8 +15,5 @@ extern "C" {
     // wxBitmapBundle compatibility hack(for a while)
     void *wxBitmapBundle_From(wxBitmap *bitmap);
 
-    // wxCLASSINFO()
-    wxClassInfo *wxCheckListBox_CLASSINFO();
-
     int wxRustMessageBox(const wxString *message, const wxString *caption, int style, wxWindow *parent, int x, int y);
 }

--- a/wx-core/src/generated.cpp
+++ b/wx-core/src/generated.cpp
@@ -3,6 +3,9 @@
 extern "C" {
 
 // CLASS: wxAnyButton
+wxClassInfo *wxAnyButton_CLASSINFO() {
+    return wxCLASSINFO(wxAnyButton);
+}
 wxAnyButton *wxAnyButton_new() {
     return new wxAnyButton();
 }
@@ -56,6 +59,9 @@ void wxAnyButton_SetBitmapPosition(wxAnyButton * self, wxDirection dir) {
 }
 
 // CLASS: wxArtProvider
+wxClassInfo *wxArtProvider_CLASSINFO() {
+    return wxCLASSINFO(wxArtProvider);
+}
 bool wxArtProvider_Delete(wxArtProvider * provider) {
     return wxArtProvider::Delete(provider);
 }
@@ -109,6 +115,9 @@ wxIcon *wxArtProvider_GetMessageBoxIcon(int flags) {
 }
 
 // CLASS: wxBitmap
+wxClassInfo *wxBitmap_CLASSINFO() {
+    return wxCLASSINFO(wxBitmap);
+}
 wxBitmap *wxBitmap_new() {
     return new wxBitmap();
 }
@@ -377,6 +386,9 @@ wxBitmapBundle *wxBitmapBundle_FromSVGResource(const wxString * name, const wxSi
 #endif
 
 // CLASS: wxBitmapButton
+wxClassInfo *wxBitmapButton_CLASSINFO() {
+    return wxCLASSINFO(wxBitmapButton);
+}
 wxBitmapButton *wxBitmapButton_new() {
     return new wxBitmapButton();
 }
@@ -396,6 +408,9 @@ wxBitmapButton * wxBitmapButton_NewCloseButton(wxWindow * parent, wxWindowID win
 #endif
 
 // CLASS: wxBookCtrlBase
+wxClassInfo *wxBookCtrlBase_CLASSINFO() {
+    return wxCLASSINFO(wxBookCtrlBase);
+}
 int wxBookCtrlBase_GetPageImage(const wxBookCtrlBase * self, size_t n_page) {
     return self->GetPageImage(n_page);
 }
@@ -458,6 +473,9 @@ bool wxBookCtrlBase_Create(wxBookCtrlBase * self, wxWindow * parent, wxWindowID 
 }
 
 // CLASS: wxBookCtrlEvent
+wxClassInfo *wxBookCtrlEvent_CLASSINFO() {
+    return wxCLASSINFO(wxBookCtrlEvent);
+}
 int wxBookCtrlEvent_GetOldSelection(const wxBookCtrlEvent * self) {
     return self->GetOldSelection();
 }
@@ -472,6 +490,9 @@ void wxBookCtrlEvent_SetSelection(wxBookCtrlEvent * self, int page) {
 }
 
 // CLASS: wxBoxSizer
+wxClassInfo *wxBoxSizer_CLASSINFO() {
+    return wxCLASSINFO(wxBoxSizer);
+}
 wxBoxSizer *wxBoxSizer_new(int orient) {
     return new wxBoxSizer(orient);
 }
@@ -483,6 +504,9 @@ void wxBoxSizer_SetOrientation(wxBoxSizer * self, int orient) {
 }
 
 // CLASS: wxButton
+wxClassInfo *wxButton_CLASSINFO() {
+    return wxCLASSINFO(wxButton);
+}
 wxButton *wxButton_new() {
     return new wxButton();
 }
@@ -508,6 +532,9 @@ wxSize *wxButton_GetDefaultSize(wxWindow * win) {
 #endif
 
 // CLASS: wxCheckBox
+wxClassInfo *wxCheckBox_CLASSINFO() {
+    return wxCLASSINFO(wxCheckBox);
+}
 wxCheckBox *wxCheckBox_new() {
     return new wxCheckBox();
 }
@@ -540,6 +567,9 @@ void wxCheckBox_Set3StateValue(wxCheckBox * self, wxCheckBoxState state) {
 }
 
 // CLASS: wxCheckListBox
+wxClassInfo *wxCheckListBox_CLASSINFO() {
+    return wxCLASSINFO(wxCheckListBox);
+}
 wxCheckListBox *wxCheckListBox_new() {
     return new wxCheckListBox();
 }
@@ -564,6 +594,9 @@ wxItemContainer *wxCheckListBox_AsItemContainer(wxCheckListBox* obj) {
 }
 
 // CLASS: wxChoice
+wxClassInfo *wxChoice_CLASSINFO() {
+    return wxCLASSINFO(wxChoice);
+}
 wxChoice *wxChoice_new() {
     return new wxChoice();
 }
@@ -591,6 +624,9 @@ wxItemContainer *wxChoice_AsItemContainer(wxChoice* obj) {
 }
 
 // CLASS: wxColour
+wxClassInfo *wxColour_CLASSINFO() {
+    return wxCLASSINFO(wxColour);
+}
 wxColour *wxColour_new() {
     return new wxColour();
 }
@@ -647,6 +683,9 @@ void wxColour_ChangeLightness1(unsigned char * r, unsigned char * g, unsigned ch
 }
 
 // CLASS: wxColourPickerCtrl
+wxClassInfo *wxColourPickerCtrl_CLASSINFO() {
+    return wxCLASSINFO(wxColourPickerCtrl);
+}
 wxColourPickerCtrl *wxColourPickerCtrl_new() {
     return new wxColourPickerCtrl();
 }
@@ -664,6 +703,9 @@ void wxColourPickerCtrl_SetColour(wxColourPickerCtrl * self, const wxColour * co
 }
 
 // CLASS: wxComboBox
+wxClassInfo *wxComboBox_CLASSINFO() {
+    return wxCLASSINFO(wxComboBox);
+}
 wxComboBox *wxComboBox_new() {
     return new wxComboBox();
 }
@@ -697,6 +739,9 @@ wxTextEntry *wxComboBox_AsTextEntry(wxComboBox* obj) {
 }
 
 // CLASS: wxCommandEvent
+wxClassInfo *wxCommandEvent_CLASSINFO() {
+    return wxCLASSINFO(wxCommandEvent);
+}
 void * wxCommandEvent_GetClientData(const wxCommandEvent * self) {
     return self->GetClientData();
 }
@@ -738,6 +783,9 @@ void wxCommandEvent_SetString(wxCommandEvent * self, const wxString * string) {
 }
 
 // CLASS: wxControl
+wxClassInfo *wxControl_CLASSINFO() {
+    return wxCLASSINFO(wxControl);
+}
 wxControl *wxControl_new(wxWindow * parent, wxWindowID id, const wxPoint * pos, const wxSize * size, long style, const wxValidator * validator, const wxString * name) {
     return new wxControl(parent, id, *pos, *size, style, *validator, *name);
 }
@@ -784,6 +832,9 @@ wxString *wxControl_Ellipsize(const wxString * label, const wxDC * dc, wxEllipsi
 }
 
 // CLASS: wxDatePickerCtrl
+wxClassInfo *wxDatePickerCtrl_CLASSINFO() {
+    return wxCLASSINFO(wxDatePickerCtrl);
+}
 wxDatePickerCtrl *wxDatePickerCtrl_new() {
     return new wxDatePickerCtrl();
 }
@@ -812,6 +863,9 @@ void wxDatePickerCtrl_SetValue(wxDatePickerCtrl * self, const wxDateTime * dt) {
 }
 
 // CLASS: wxDirPickerCtrl
+wxClassInfo *wxDirPickerCtrl_CLASSINFO() {
+    return wxCLASSINFO(wxDirPickerCtrl);
+}
 wxDirPickerCtrl *wxDirPickerCtrl_new() {
     return new wxDirPickerCtrl();
 }
@@ -838,6 +892,9 @@ void wxDirPickerCtrl_SetPath(wxDirPickerCtrl * self, const wxString * dirname) {
 }
 
 // CLASS: wxEditableListBox
+wxClassInfo *wxEditableListBox_CLASSINFO() {
+    return wxCLASSINFO(wxEditableListBox);
+}
 wxEditableListBox *wxEditableListBox_new() {
     return new wxEditableListBox();
 }
@@ -855,6 +912,9 @@ void wxEditableListBox_GetStrings(const wxEditableListBox * self, wxArrayString 
 }
 
 // CLASS: wxFileCtrl
+wxClassInfo *wxFileCtrl_CLASSINFO() {
+    return wxCLASSINFO(wxFileCtrl);
+}
 wxFileCtrl *wxFileCtrl_new() {
     return new wxFileCtrl();
 }
@@ -905,6 +965,9 @@ void wxFileCtrl_ShowHidden(wxFileCtrl * self, bool show) {
 }
 
 // CLASS: wxFont
+wxClassInfo *wxFont_CLASSINFO() {
+    return wxCLASSINFO(wxFont);
+}
 #if wxCHECK_VERSION(3, 1, 0)
 wxFont *wxFont_GetBaseFont(const wxFont * self) {
     return new wxFont(self->GetBaseFont());
@@ -1048,6 +1111,9 @@ wxFont *wxFont_new6(const wxNativeFontInfo * native_info) {
 }
 
 // CLASS: wxFontPickerCtrl
+wxClassInfo *wxFontPickerCtrl_CLASSINFO() {
+    return wxCLASSINFO(wxFontPickerCtrl);
+}
 wxFontPickerCtrl *wxFontPickerCtrl_new() {
     return new wxFontPickerCtrl();
 }
@@ -1087,6 +1153,9 @@ void wxFontPickerCtrl_SetSelectedFont(wxFontPickerCtrl * self, const wxFont * fo
 }
 
 // CLASS: wxFrame
+wxClassInfo *wxFrame_CLASSINFO() {
+    return wxCLASSINFO(wxFrame);
+}
 wxFrame *wxFrame_new() {
     return new wxFrame();
 }
@@ -1160,8 +1229,14 @@ void wxFrame_PopStatusText(wxFrame * self, int number) {
 }
 
 // CLASS: wxGDIObject
+wxClassInfo *wxGDIObject_CLASSINFO() {
+    return wxCLASSINFO(wxGDIObject);
+}
 
 // CLASS: wxGauge
+wxClassInfo *wxGauge_CLASSINFO() {
+    return wxCLASSINFO(wxGauge);
+}
 wxGauge *wxGauge_new() {
     return new wxGauge();
 }
@@ -1191,6 +1266,9 @@ void wxGauge_SetValue(wxGauge * self, int pos) {
 }
 
 // CLASS: wxGenericDirCtrl
+wxClassInfo *wxGenericDirCtrl_CLASSINFO() {
+    return wxCLASSINFO(wxGenericDirCtrl);
+}
 wxGenericDirCtrl *wxGenericDirCtrl_new() {
     return new wxGenericDirCtrl();
 }
@@ -1331,6 +1409,9 @@ wxHeaderColumnSimple *wxHeaderColumnSimple_new1(const wxBitmapBundle * bitmap, i
 }
 
 // CLASS: wxHeaderCtrl
+wxClassInfo *wxHeaderCtrl_CLASSINFO() {
+    return wxCLASSINFO(wxHeaderCtrl);
+}
 bool wxHeaderCtrl_Create(wxHeaderCtrl * self, wxWindow * parent, wxWindowID winid, const wxPoint * pos, const wxSize * size, long style, const wxString * name) {
     return self->Create(parent, winid, *pos, *size, style, *name);
 }
@@ -1383,6 +1464,9 @@ void wxHeaderCtrl_MoveColumnInOrderArray(wxArrayInt * order, unsigned int idx, u
 }
 
 // CLASS: wxHeaderCtrlSimple
+wxClassInfo *wxHeaderCtrlSimple_CLASSINFO() {
+    return wxCLASSINFO(wxHeaderCtrlSimple);
+}
 wxHeaderCtrlSimple *wxHeaderCtrlSimple_new() {
     return new wxHeaderCtrlSimple();
 }
@@ -1412,6 +1496,9 @@ void wxHeaderCtrlSimple_RemoveSortIndicator(wxHeaderCtrlSimple * self) {
 }
 
 // CLASS: wxHyperlinkCtrl
+wxClassInfo *wxHyperlinkCtrl_CLASSINFO() {
+    return wxCLASSINFO(wxHyperlinkCtrl);
+}
 wxHyperlinkCtrl *wxHyperlinkCtrl_new() {
     return new wxHyperlinkCtrl();
 }
@@ -1453,6 +1540,9 @@ void wxHyperlinkCtrl_SetVisitedColour(wxHyperlinkCtrl * self, const wxColour * c
 }
 
 // CLASS: wxIcon
+wxClassInfo *wxIcon_CLASSINFO() {
+    return wxCLASSINFO(wxIcon);
+}
 wxIcon *wxIcon_new() {
     return new wxIcon();
 }
@@ -1655,6 +1745,9 @@ int wxItemContainerImmutable_FindString(const wxItemContainerImmutable * self, c
 }
 
 // CLASS: wxListBox
+wxClassInfo *wxListBox_CLASSINFO() {
+    return wxCLASSINFO(wxListBox);
+}
 wxListBox *wxListBox_new() {
     return new wxListBox();
 }
@@ -1714,6 +1807,9 @@ wxItemContainer *wxListBox_AsItemContainer(wxListBox* obj) {
 }
 
 // CLASS: wxMenu
+wxClassInfo *wxMenu_CLASSINFO() {
+    return wxCLASSINFO(wxMenu);
+}
 wxMenu *wxMenu_new() {
     return new wxMenu();
 }
@@ -1881,6 +1977,9 @@ bool wxMenu_IsAttached(const wxMenu * self) {
 }
 
 // CLASS: wxMenuBar
+wxClassInfo *wxMenuBar_CLASSINFO() {
+    return wxCLASSINFO(wxMenuBar);
+}
 wxMenuBar *wxMenuBar_new(long style) {
     return new wxMenuBar(style);
 }
@@ -1977,6 +2076,9 @@ wxMenuBar * wxMenuBar_MacGetCommonMenuBar() {
 #endif
 
 // CLASS: wxMenuItem
+wxClassInfo *wxMenuItem_CLASSINFO() {
+    return wxCLASSINFO(wxMenuItem);
+}
 wxBitmap *wxMenuItem_GetBitmap(const wxMenuItem * self) {
     return new wxBitmap(self->GetBitmap());
 }
@@ -2114,6 +2216,9 @@ wxString *wxMenuItem_GetLabelText(const wxString * text) {
 }
 
 // CLASS: wxNonOwnedWindow
+wxClassInfo *wxNonOwnedWindow_CLASSINFO() {
+    return wxCLASSINFO(wxNonOwnedWindow);
+}
 bool wxNonOwnedWindow_SetShape(wxNonOwnedWindow * self, const wxRegion * region) {
     return self->SetShape(*region);
 }
@@ -2122,6 +2227,9 @@ bool wxNonOwnedWindow_SetShape1(wxNonOwnedWindow * self, const wxGraphicsPath * 
 }
 
 // CLASS: wxNotebook
+wxClassInfo *wxNotebook_CLASSINFO() {
+    return wxCLASSINFO(wxNotebook);
+}
 wxNotebook *wxNotebook_new() {
     return new wxNotebook();
 }
@@ -2139,6 +2247,9 @@ void wxNotebook_SetPadding(wxNotebook * self, const wxSize * padding) {
 }
 
 // CLASS: wxNotifyEvent
+wxClassInfo *wxNotifyEvent_CLASSINFO() {
+    return wxCLASSINFO(wxNotifyEvent);
+}
 void wxNotifyEvent_Allow(wxNotifyEvent * self) {
     return self->Allow();
 }
@@ -2150,6 +2261,9 @@ void wxNotifyEvent_Veto(wxNotifyEvent * self) {
 }
 
 // CLASS: wxPanel
+wxClassInfo *wxPanel_CLASSINFO() {
+    return wxCLASSINFO(wxPanel);
+}
 wxPanel *wxPanel_new() {
     return new wxPanel();
 }
@@ -2167,6 +2281,9 @@ void wxPanel_SetFocusIgnoringChildren(wxPanel * self) {
 }
 
 // CLASS: wxPickerBase
+wxClassInfo *wxPickerBase_CLASSINFO() {
+    return wxCLASSINFO(wxPickerBase);
+}
 bool wxPickerBase_CreateBase(wxPickerBase * self, wxWindow * parent, wxWindowID id, const wxString * text, const wxPoint * pos, const wxSize * size, long style, const wxValidator * validator, const wxString * name) {
     return self->CreateBase(parent, id, *text, *pos, *size, style, *validator, *name);
 }
@@ -2243,6 +2360,9 @@ wxPoint *wxPoint_new2(const wxRealPoint * pt) {
 }
 
 // CLASS: wxRadioBox
+wxClassInfo *wxRadioBox_CLASSINFO() {
+    return wxCLASSINFO(wxRadioBox);
+}
 wxRadioBox *wxRadioBox_new() {
     return new wxRadioBox();
 }
@@ -2557,6 +2677,9 @@ void wxSize_SetWidth(wxSize * self, int width) {
 }
 
 // CLASS: wxSizer
+wxClassInfo *wxSizer_CLASSINFO() {
+    return wxCLASSINFO(wxSizer);
+}
 wxSizerItem * wxSizer_Add(wxSizer * self, wxWindow * window, const wxSizerFlags * flags) {
     return self->Add(window, *flags);
 }
@@ -2873,6 +2996,9 @@ int wxSizerFlags_GetDefaultBorder() {
 }
 
 // CLASS: wxStaticBitmap
+wxClassInfo *wxStaticBitmap_CLASSINFO() {
+    return wxCLASSINFO(wxStaticBitmap);
+}
 wxStaticBitmap *wxStaticBitmap_new() {
     return new wxStaticBitmap();
 }
@@ -2896,6 +3022,9 @@ void wxStaticBitmap_SetIcon(wxStaticBitmap * self, const wxIcon * label) {
 }
 
 // CLASS: wxStaticBox
+wxClassInfo *wxStaticBox_CLASSINFO() {
+    return wxCLASSINFO(wxStaticBox);
+}
 wxStaticBox *wxStaticBox_new() {
     return new wxStaticBox();
 }
@@ -2907,6 +3036,9 @@ bool wxStaticBox_Create(wxStaticBox * self, wxWindow * parent, wxWindowID id, co
 }
 
 // CLASS: wxStaticBoxSizer
+wxClassInfo *wxStaticBoxSizer_CLASSINFO() {
+    return wxCLASSINFO(wxStaticBoxSizer);
+}
 wxStaticBoxSizer *wxStaticBoxSizer_new(wxStaticBox * box_, int orient) {
     return new wxStaticBoxSizer(box_, orient);
 }
@@ -2918,6 +3050,9 @@ wxStaticBox * wxStaticBoxSizer_GetStaticBox(const wxStaticBoxSizer * self) {
 }
 
 // CLASS: wxStaticText
+wxClassInfo *wxStaticText_CLASSINFO() {
+    return wxCLASSINFO(wxStaticText);
+}
 wxStaticText *wxStaticText_new() {
     return new wxStaticText();
 }
@@ -3230,6 +3365,9 @@ wxTextAttr *wxTextAttr_Merge1(const wxTextAttr * base, const wxTextAttr * overla
 }
 
 // CLASS: wxTextCtrl
+wxClassInfo *wxTextCtrl_CLASSINFO() {
+    return wxCLASSINFO(wxTextCtrl);
+}
 #ifdef __WXOSX__
 void wxTextCtrl_OSXEnableNewLineReplacement(wxTextCtrl * self, bool enable) {
     return self->OSXEnableNewLineReplacement(enable);
@@ -3450,6 +3588,9 @@ void wxTextEntry_WriteText(wxTextEntry * self, const wxString * text) {
 }
 
 // CLASS: wxToolBar
+wxClassInfo *wxToolBar_CLASSINFO() {
+    return wxCLASSINFO(wxToolBar);
+}
 wxToolBar *wxToolBar_new() {
     return new wxToolBar();
 }
@@ -3617,6 +3758,9 @@ wxToolBarToolBase * wxToolBar_CreateSeparator(wxToolBar * self) {
 }
 
 // CLASS: wxTopLevelWindow
+wxClassInfo *wxTopLevelWindow_CLASSINFO() {
+    return wxCLASSINFO(wxTopLevelWindow);
+}
 wxTopLevelWindow *wxTopLevelWindow_new() {
     return new wxTopLevelWindow();
 }
@@ -3730,6 +3874,9 @@ wxSize *wxTopLevelWindow_GetDefaultSize() {
 }
 
 // CLASS: wxValidator
+wxClassInfo *wxValidator_CLASSINFO() {
+    return wxCLASSINFO(wxValidator);
+}
 wxValidator *wxValidator_new() {
     return new wxValidator();
 }
@@ -3759,6 +3906,9 @@ bool wxValidator_IsSilent() {
 }
 
 // CLASS: wxWindow
+wxClassInfo *wxWindow_CLASSINFO() {
+    return wxCLASSINFO(wxWindow);
+}
 bool wxWindow_AcceptsFocus(const wxWindow * self) {
     return self->AcceptsFocus();
 }
@@ -4632,6 +4782,9 @@ bool wxWindow_Create(wxWindow * self, wxWindow * parent, wxWindowID id, const wx
 }
 
 // CLASS: wxWrapSizer
+wxClassInfo *wxWrapSizer_CLASSINFO() {
+    return wxCLASSINFO(wxWrapSizer);
+}
 wxWrapSizer *wxWrapSizer_new(int orient, int flags) {
     return new wxWrapSizer(orient, flags);
 }

--- a/wx-core/src/generated.rs
+++ b/wx-core/src/generated.rs
@@ -493,6 +493,16 @@ impl<const OWNED: bool> From<CheckListBoxIsOwned<OWNED>> for ListBoxIsOwned<OWNE
         unsafe { ListBoxIsOwned::from_ptr(o.as_ptr()) }
     }
 }
+impl<const OWNED: bool> TryFrom<&ListBoxIsOwned<OWNED>> for CheckListBoxIsOwned<false> {
+    type Error = ();
+    fn try_from(lbox: &ListBoxIsOwned<OWNED>) -> Result<Self, Self::Error> {
+        if lbox.is_kind_of(Some(&CheckListBox::class_info())) {
+            unsafe { Ok(CheckListBox::from_unowned_ptr(lbox.as_ptr())) }
+        } else {
+            Err(())
+        }
+    }
+}
 
 // wxChoice
 wx_class! { Choice =

--- a/wx-core/src/generated.rs
+++ b/wx-core/src/generated.rs
@@ -34,22 +34,22 @@ impl<const OWNED: bool> AnyButtonIsOwned<OWNED> {
 }
 impl<const OWNED: bool> From<AnyButtonIsOwned<OWNED>> for ControlIsOwned<OWNED> {
     fn from(o: AnyButtonIsOwned<OWNED>) -> Self {
-        unsafe { ControlIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<AnyButtonIsOwned<OWNED>> for WindowIsOwned<OWNED> {
     fn from(o: AnyButtonIsOwned<OWNED>) -> Self {
-        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<AnyButtonIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
     fn from(o: AnyButtonIsOwned<OWNED>) -> Self {
-        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<AnyButtonIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
     fn from(o: AnyButtonIsOwned<OWNED>) -> Self {
-        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for AnyButtonIsOwned<OWNED> {
@@ -71,7 +71,7 @@ impl<const OWNED: bool> ArtProviderIsOwned<OWNED> {
 }
 impl<const OWNED: bool> From<ArtProviderIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
     fn from(o: ArtProviderIsOwned<OWNED>) -> Self {
-        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for ArtProviderIsOwned<OWNED> {
@@ -136,12 +136,12 @@ impl<const OWNED: bool> BitmapIsOwned<OWNED> {
 }
 impl<const OWNED: bool> From<BitmapIsOwned<OWNED>> for GDIObjectIsOwned<OWNED> {
     fn from(o: BitmapIsOwned<OWNED>) -> Self {
-        unsafe { GDIObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<BitmapIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
     fn from(o: BitmapIsOwned<OWNED>) -> Self {
-        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for BitmapIsOwned<OWNED> {
@@ -255,32 +255,32 @@ impl<const OWNED: bool> BitmapButtonIsOwned<OWNED> {
 }
 impl<const OWNED: bool> From<BitmapButtonIsOwned<OWNED>> for ButtonIsOwned<OWNED> {
     fn from(o: BitmapButtonIsOwned<OWNED>) -> Self {
-        unsafe { ButtonIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<BitmapButtonIsOwned<OWNED>> for AnyButtonIsOwned<OWNED> {
     fn from(o: BitmapButtonIsOwned<OWNED>) -> Self {
-        unsafe { AnyButtonIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<BitmapButtonIsOwned<OWNED>> for ControlIsOwned<OWNED> {
     fn from(o: BitmapButtonIsOwned<OWNED>) -> Self {
-        unsafe { ControlIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<BitmapButtonIsOwned<OWNED>> for WindowIsOwned<OWNED> {
     fn from(o: BitmapButtonIsOwned<OWNED>) -> Self {
-        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<BitmapButtonIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
     fn from(o: BitmapButtonIsOwned<OWNED>) -> Self {
-        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<BitmapButtonIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
     fn from(o: BitmapButtonIsOwned<OWNED>) -> Self {
-        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for BitmapButtonIsOwned<OWNED> {
@@ -310,22 +310,22 @@ impl<const OWNED: bool> BookCtrlBaseIsOwned<OWNED> {
 }
 impl<const OWNED: bool> From<BookCtrlBaseIsOwned<OWNED>> for ControlIsOwned<OWNED> {
     fn from(o: BookCtrlBaseIsOwned<OWNED>) -> Self {
-        unsafe { ControlIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<BookCtrlBaseIsOwned<OWNED>> for WindowIsOwned<OWNED> {
     fn from(o: BookCtrlBaseIsOwned<OWNED>) -> Self {
-        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<BookCtrlBaseIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
     fn from(o: BookCtrlBaseIsOwned<OWNED>) -> Self {
-        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<BookCtrlBaseIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
     fn from(o: BookCtrlBaseIsOwned<OWNED>) -> Self {
-        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for BookCtrlBaseIsOwned<OWNED> {
@@ -374,22 +374,22 @@ impl<const OWNED: bool> BookCtrlEventIsOwned<OWNED> {
 }
 impl<const OWNED: bool> From<BookCtrlEventIsOwned<OWNED>> for NotifyEventIsOwned<OWNED> {
     fn from(o: BookCtrlEventIsOwned<OWNED>) -> Self {
-        unsafe { NotifyEventIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<BookCtrlEventIsOwned<OWNED>> for CommandEventIsOwned<OWNED> {
     fn from(o: BookCtrlEventIsOwned<OWNED>) -> Self {
-        unsafe { CommandEventIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<BookCtrlEventIsOwned<OWNED>> for EventIsOwned<OWNED> {
     fn from(o: BookCtrlEventIsOwned<OWNED>) -> Self {
-        unsafe { EventIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<BookCtrlEventIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
     fn from(o: BookCtrlEventIsOwned<OWNED>) -> Self {
-        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for BookCtrlEventIsOwned<OWNED> {
@@ -427,12 +427,12 @@ impl<const OWNED: bool> BoxSizerIsOwned<OWNED> {
 }
 impl<const OWNED: bool> From<BoxSizerIsOwned<OWNED>> for SizerIsOwned<OWNED> {
     fn from(o: BoxSizerIsOwned<OWNED>) -> Self {
-        unsafe { SizerIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<BoxSizerIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
     fn from(o: BoxSizerIsOwned<OWNED>) -> Self {
-        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for BoxSizerIsOwned<OWNED> {
@@ -488,27 +488,27 @@ impl<const OWNED: bool> ButtonIsOwned<OWNED> {
 }
 impl<const OWNED: bool> From<ButtonIsOwned<OWNED>> for AnyButtonIsOwned<OWNED> {
     fn from(o: ButtonIsOwned<OWNED>) -> Self {
-        unsafe { AnyButtonIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<ButtonIsOwned<OWNED>> for ControlIsOwned<OWNED> {
     fn from(o: ButtonIsOwned<OWNED>) -> Self {
-        unsafe { ControlIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<ButtonIsOwned<OWNED>> for WindowIsOwned<OWNED> {
     fn from(o: ButtonIsOwned<OWNED>) -> Self {
-        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<ButtonIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
     fn from(o: ButtonIsOwned<OWNED>) -> Self {
-        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<ButtonIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
     fn from(o: ButtonIsOwned<OWNED>) -> Self {
-        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for ButtonIsOwned<OWNED> {
@@ -563,22 +563,22 @@ impl<const OWNED: bool> CheckBoxIsOwned<OWNED> {
 }
 impl<const OWNED: bool> From<CheckBoxIsOwned<OWNED>> for ControlIsOwned<OWNED> {
     fn from(o: CheckBoxIsOwned<OWNED>) -> Self {
-        unsafe { ControlIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<CheckBoxIsOwned<OWNED>> for WindowIsOwned<OWNED> {
     fn from(o: CheckBoxIsOwned<OWNED>) -> Self {
-        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<CheckBoxIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
     fn from(o: CheckBoxIsOwned<OWNED>) -> Self {
-        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<CheckBoxIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
     fn from(o: CheckBoxIsOwned<OWNED>) -> Self {
-        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for CheckBoxIsOwned<OWNED> {
@@ -640,27 +640,27 @@ impl<const OWNED: bool> CheckListBoxIsOwned<OWNED> {
 }
 impl<const OWNED: bool> From<CheckListBoxIsOwned<OWNED>> for ListBoxIsOwned<OWNED> {
     fn from(o: CheckListBoxIsOwned<OWNED>) -> Self {
-        unsafe { ListBoxIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<CheckListBoxIsOwned<OWNED>> for ControlIsOwned<OWNED> {
     fn from(o: CheckListBoxIsOwned<OWNED>) -> Self {
-        unsafe { ControlIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<CheckListBoxIsOwned<OWNED>> for WindowIsOwned<OWNED> {
     fn from(o: CheckListBoxIsOwned<OWNED>) -> Self {
-        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<CheckListBoxIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
     fn from(o: CheckListBoxIsOwned<OWNED>) -> Self {
-        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<CheckListBoxIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
     fn from(o: CheckListBoxIsOwned<OWNED>) -> Self {
-        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for CheckListBoxIsOwned<OWNED> {
@@ -776,22 +776,22 @@ impl<const OWNED: bool> ChoiceIsOwned<OWNED> {
 }
 impl<const OWNED: bool> From<ChoiceIsOwned<OWNED>> for ControlIsOwned<OWNED> {
     fn from(o: ChoiceIsOwned<OWNED>) -> Self {
-        unsafe { ControlIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<ChoiceIsOwned<OWNED>> for WindowIsOwned<OWNED> {
     fn from(o: ChoiceIsOwned<OWNED>) -> Self {
-        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<ChoiceIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
     fn from(o: ChoiceIsOwned<OWNED>) -> Self {
-        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<ChoiceIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
     fn from(o: ChoiceIsOwned<OWNED>) -> Self {
-        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for ChoiceIsOwned<OWNED> {
@@ -842,7 +842,7 @@ impl<const OWNED: bool> ColourIsOwned<OWNED> {
 }
 impl<const OWNED: bool> From<ColourIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
     fn from(o: ColourIsOwned<OWNED>) -> Self {
-        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for ColourIsOwned<OWNED> {
@@ -910,27 +910,27 @@ impl<const OWNED: bool> ColourPickerCtrlIsOwned<OWNED> {
 }
 impl<const OWNED: bool> From<ColourPickerCtrlIsOwned<OWNED>> for PickerBaseIsOwned<OWNED> {
     fn from(o: ColourPickerCtrlIsOwned<OWNED>) -> Self {
-        unsafe { PickerBaseIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<ColourPickerCtrlIsOwned<OWNED>> for ControlIsOwned<OWNED> {
     fn from(o: ColourPickerCtrlIsOwned<OWNED>) -> Self {
-        unsafe { ControlIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<ColourPickerCtrlIsOwned<OWNED>> for WindowIsOwned<OWNED> {
     fn from(o: ColourPickerCtrlIsOwned<OWNED>) -> Self {
-        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<ColourPickerCtrlIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
     fn from(o: ColourPickerCtrlIsOwned<OWNED>) -> Self {
-        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<ColourPickerCtrlIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
     fn from(o: ColourPickerCtrlIsOwned<OWNED>) -> Self {
-        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for ColourPickerCtrlIsOwned<OWNED> {
@@ -994,22 +994,22 @@ impl<const OWNED: bool> ComboBoxIsOwned<OWNED> {
 }
 impl<const OWNED: bool> From<ComboBoxIsOwned<OWNED>> for ControlIsOwned<OWNED> {
     fn from(o: ComboBoxIsOwned<OWNED>) -> Self {
-        unsafe { ControlIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<ComboBoxIsOwned<OWNED>> for WindowIsOwned<OWNED> {
     fn from(o: ComboBoxIsOwned<OWNED>) -> Self {
-        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<ComboBoxIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
     fn from(o: ComboBoxIsOwned<OWNED>) -> Self {
-        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<ComboBoxIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
     fn from(o: ComboBoxIsOwned<OWNED>) -> Self {
-        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for ComboBoxIsOwned<OWNED> {
@@ -1049,12 +1049,12 @@ impl<const OWNED: bool> CommandEventIsOwned<OWNED> {
 }
 impl<const OWNED: bool> From<CommandEventIsOwned<OWNED>> for EventIsOwned<OWNED> {
     fn from(o: CommandEventIsOwned<OWNED>) -> Self {
-        unsafe { EventIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<CommandEventIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
     fn from(o: CommandEventIsOwned<OWNED>) -> Self {
-        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for CommandEventIsOwned<OWNED> {
@@ -1112,17 +1112,17 @@ impl<const OWNED: bool> ControlIsOwned<OWNED> {
 }
 impl<const OWNED: bool> From<ControlIsOwned<OWNED>> for WindowIsOwned<OWNED> {
     fn from(o: ControlIsOwned<OWNED>) -> Self {
-        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<ControlIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
     fn from(o: ControlIsOwned<OWNED>) -> Self {
-        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<ControlIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
     fn from(o: ControlIsOwned<OWNED>) -> Self {
-        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for ControlIsOwned<OWNED> {
@@ -1182,22 +1182,22 @@ impl<const OWNED: bool> DatePickerCtrlIsOwned<OWNED> {
 }
 impl<const OWNED: bool> From<DatePickerCtrlIsOwned<OWNED>> for ControlIsOwned<OWNED> {
     fn from(o: DatePickerCtrlIsOwned<OWNED>) -> Self {
-        unsafe { ControlIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<DatePickerCtrlIsOwned<OWNED>> for WindowIsOwned<OWNED> {
     fn from(o: DatePickerCtrlIsOwned<OWNED>) -> Self {
-        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<DatePickerCtrlIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
     fn from(o: DatePickerCtrlIsOwned<OWNED>) -> Self {
-        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<DatePickerCtrlIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
     fn from(o: DatePickerCtrlIsOwned<OWNED>) -> Self {
-        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for DatePickerCtrlIsOwned<OWNED> {
@@ -1256,27 +1256,27 @@ impl<const OWNED: bool> DirPickerCtrlIsOwned<OWNED> {
 }
 impl<const OWNED: bool> From<DirPickerCtrlIsOwned<OWNED>> for PickerBaseIsOwned<OWNED> {
     fn from(o: DirPickerCtrlIsOwned<OWNED>) -> Self {
-        unsafe { PickerBaseIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<DirPickerCtrlIsOwned<OWNED>> for ControlIsOwned<OWNED> {
     fn from(o: DirPickerCtrlIsOwned<OWNED>) -> Self {
-        unsafe { ControlIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<DirPickerCtrlIsOwned<OWNED>> for WindowIsOwned<OWNED> {
     fn from(o: DirPickerCtrlIsOwned<OWNED>) -> Self {
-        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<DirPickerCtrlIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
     fn from(o: DirPickerCtrlIsOwned<OWNED>) -> Self {
-        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<DirPickerCtrlIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
     fn from(o: DirPickerCtrlIsOwned<OWNED>) -> Self {
-        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for DirPickerCtrlIsOwned<OWNED> {
@@ -1329,22 +1329,22 @@ impl<const OWNED: bool> EditableListBoxIsOwned<OWNED> {
 }
 impl<const OWNED: bool> From<EditableListBoxIsOwned<OWNED>> for PanelIsOwned<OWNED> {
     fn from(o: EditableListBoxIsOwned<OWNED>) -> Self {
-        unsafe { PanelIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<EditableListBoxIsOwned<OWNED>> for WindowIsOwned<OWNED> {
     fn from(o: EditableListBoxIsOwned<OWNED>) -> Self {
-        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<EditableListBoxIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
     fn from(o: EditableListBoxIsOwned<OWNED>) -> Self {
-        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<EditableListBoxIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
     fn from(o: EditableListBoxIsOwned<OWNED>) -> Self {
-        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for EditableListBoxIsOwned<OWNED> {
@@ -1411,22 +1411,22 @@ impl<const OWNED: bool> FileCtrlIsOwned<OWNED> {
 }
 impl<const OWNED: bool> From<FileCtrlIsOwned<OWNED>> for ControlIsOwned<OWNED> {
     fn from(o: FileCtrlIsOwned<OWNED>) -> Self {
-        unsafe { ControlIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<FileCtrlIsOwned<OWNED>> for WindowIsOwned<OWNED> {
     fn from(o: FileCtrlIsOwned<OWNED>) -> Self {
-        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<FileCtrlIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
     fn from(o: FileCtrlIsOwned<OWNED>) -> Self {
-        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<FileCtrlIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
     fn from(o: FileCtrlIsOwned<OWNED>) -> Self {
-        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for FileCtrlIsOwned<OWNED> {
@@ -1473,12 +1473,12 @@ impl<const OWNED: bool> FontIsOwned<OWNED> {
 }
 impl<const OWNED: bool> From<FontIsOwned<OWNED>> for GDIObjectIsOwned<OWNED> {
     fn from(o: FontIsOwned<OWNED>) -> Self {
-        unsafe { GDIObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<FontIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
     fn from(o: FontIsOwned<OWNED>) -> Self {
-        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for FontIsOwned<OWNED> {
@@ -1546,27 +1546,27 @@ impl<const OWNED: bool> FontPickerCtrlIsOwned<OWNED> {
 }
 impl<const OWNED: bool> From<FontPickerCtrlIsOwned<OWNED>> for PickerBaseIsOwned<OWNED> {
     fn from(o: FontPickerCtrlIsOwned<OWNED>) -> Self {
-        unsafe { PickerBaseIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<FontPickerCtrlIsOwned<OWNED>> for ControlIsOwned<OWNED> {
     fn from(o: FontPickerCtrlIsOwned<OWNED>) -> Self {
-        unsafe { ControlIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<FontPickerCtrlIsOwned<OWNED>> for WindowIsOwned<OWNED> {
     fn from(o: FontPickerCtrlIsOwned<OWNED>) -> Self {
-        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<FontPickerCtrlIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
     fn from(o: FontPickerCtrlIsOwned<OWNED>) -> Self {
-        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<FontPickerCtrlIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
     fn from(o: FontPickerCtrlIsOwned<OWNED>) -> Self {
-        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for FontPickerCtrlIsOwned<OWNED> {
@@ -1618,27 +1618,27 @@ impl<const OWNED: bool> FrameIsOwned<OWNED> {
 }
 impl<const OWNED: bool> From<FrameIsOwned<OWNED>> for TopLevelWindowIsOwned<OWNED> {
     fn from(o: FrameIsOwned<OWNED>) -> Self {
-        unsafe { TopLevelWindowIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<FrameIsOwned<OWNED>> for NonOwnedWindowIsOwned<OWNED> {
     fn from(o: FrameIsOwned<OWNED>) -> Self {
-        unsafe { NonOwnedWindowIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<FrameIsOwned<OWNED>> for WindowIsOwned<OWNED> {
     fn from(o: FrameIsOwned<OWNED>) -> Self {
-        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<FrameIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
     fn from(o: FrameIsOwned<OWNED>) -> Self {
-        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<FrameIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
     fn from(o: FrameIsOwned<OWNED>) -> Self {
-        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for FrameIsOwned<OWNED> {
@@ -1692,7 +1692,7 @@ impl<const OWNED: bool> GDIObjectIsOwned<OWNED> {
 }
 impl<const OWNED: bool> From<GDIObjectIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
     fn from(o: GDIObjectIsOwned<OWNED>) -> Self {
-        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for GDIObjectIsOwned<OWNED> {
@@ -1752,22 +1752,22 @@ impl<const OWNED: bool> GaugeIsOwned<OWNED> {
 }
 impl<const OWNED: bool> From<GaugeIsOwned<OWNED>> for ControlIsOwned<OWNED> {
     fn from(o: GaugeIsOwned<OWNED>) -> Self {
-        unsafe { ControlIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<GaugeIsOwned<OWNED>> for WindowIsOwned<OWNED> {
     fn from(o: GaugeIsOwned<OWNED>) -> Self {
-        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<GaugeIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
     fn from(o: GaugeIsOwned<OWNED>) -> Self {
-        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<GaugeIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
     fn from(o: GaugeIsOwned<OWNED>) -> Self {
-        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for GaugeIsOwned<OWNED> {
@@ -1832,22 +1832,22 @@ impl<const OWNED: bool> GenericDirCtrlIsOwned<OWNED> {
 }
 impl<const OWNED: bool> From<GenericDirCtrlIsOwned<OWNED>> for ControlIsOwned<OWNED> {
     fn from(o: GenericDirCtrlIsOwned<OWNED>) -> Self {
-        unsafe { ControlIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<GenericDirCtrlIsOwned<OWNED>> for WindowIsOwned<OWNED> {
     fn from(o: GenericDirCtrlIsOwned<OWNED>) -> Self {
-        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<GenericDirCtrlIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
     fn from(o: GenericDirCtrlIsOwned<OWNED>) -> Self {
-        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<GenericDirCtrlIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
     fn from(o: GenericDirCtrlIsOwned<OWNED>) -> Self {
-        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for GenericDirCtrlIsOwned<OWNED> {
@@ -1913,12 +1913,12 @@ impl<const OWNED: bool> From<HeaderColumnSimpleIsOwned<OWNED>>
     for SettableHeaderColumnIsOwned<OWNED>
 {
     fn from(o: HeaderColumnSimpleIsOwned<OWNED>) -> Self {
-        unsafe { SettableHeaderColumnIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<HeaderColumnSimpleIsOwned<OWNED>> for HeaderColumnIsOwned<OWNED> {
     fn from(o: HeaderColumnSimpleIsOwned<OWNED>) -> Self {
-        unsafe { HeaderColumnIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> Drop for HeaderColumnSimpleIsOwned<OWNED> {
@@ -1947,22 +1947,22 @@ impl<const OWNED: bool> HeaderCtrlIsOwned<OWNED> {
 }
 impl<const OWNED: bool> From<HeaderCtrlIsOwned<OWNED>> for ControlIsOwned<OWNED> {
     fn from(o: HeaderCtrlIsOwned<OWNED>) -> Self {
-        unsafe { ControlIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<HeaderCtrlIsOwned<OWNED>> for WindowIsOwned<OWNED> {
     fn from(o: HeaderCtrlIsOwned<OWNED>) -> Self {
-        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<HeaderCtrlIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
     fn from(o: HeaderCtrlIsOwned<OWNED>) -> Self {
-        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<HeaderCtrlIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
     fn from(o: HeaderCtrlIsOwned<OWNED>) -> Self {
-        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for HeaderCtrlIsOwned<OWNED> {
@@ -2036,27 +2036,27 @@ impl<const OWNED: bool> HeaderCtrlSimpleIsOwned<OWNED> {
 }
 impl<const OWNED: bool> From<HeaderCtrlSimpleIsOwned<OWNED>> for HeaderCtrlIsOwned<OWNED> {
     fn from(o: HeaderCtrlSimpleIsOwned<OWNED>) -> Self {
-        unsafe { HeaderCtrlIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<HeaderCtrlSimpleIsOwned<OWNED>> for ControlIsOwned<OWNED> {
     fn from(o: HeaderCtrlSimpleIsOwned<OWNED>) -> Self {
-        unsafe { ControlIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<HeaderCtrlSimpleIsOwned<OWNED>> for WindowIsOwned<OWNED> {
     fn from(o: HeaderCtrlSimpleIsOwned<OWNED>) -> Self {
-        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<HeaderCtrlSimpleIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
     fn from(o: HeaderCtrlSimpleIsOwned<OWNED>) -> Self {
-        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<HeaderCtrlSimpleIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
     fn from(o: HeaderCtrlSimpleIsOwned<OWNED>) -> Self {
-        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for HeaderCtrlSimpleIsOwned<OWNED> {
@@ -2112,22 +2112,22 @@ impl<const OWNED: bool> HyperlinkCtrlIsOwned<OWNED> {
 }
 impl<const OWNED: bool> From<HyperlinkCtrlIsOwned<OWNED>> for ControlIsOwned<OWNED> {
     fn from(o: HyperlinkCtrlIsOwned<OWNED>) -> Self {
-        unsafe { ControlIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<HyperlinkCtrlIsOwned<OWNED>> for WindowIsOwned<OWNED> {
     fn from(o: HyperlinkCtrlIsOwned<OWNED>) -> Self {
-        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<HyperlinkCtrlIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
     fn from(o: HyperlinkCtrlIsOwned<OWNED>) -> Self {
-        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<HyperlinkCtrlIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
     fn from(o: HyperlinkCtrlIsOwned<OWNED>) -> Self {
-        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for HyperlinkCtrlIsOwned<OWNED> {
@@ -2167,12 +2167,12 @@ impl<const OWNED: bool> IconIsOwned<OWNED> {
 }
 impl<const OWNED: bool> From<IconIsOwned<OWNED>> for GDIObjectIsOwned<OWNED> {
     fn from(o: IconIsOwned<OWNED>) -> Self {
-        unsafe { GDIObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<IconIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
     fn from(o: IconIsOwned<OWNED>) -> Self {
-        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for IconIsOwned<OWNED> {
@@ -2244,22 +2244,22 @@ impl<const OWNED: bool> ListBoxIsOwned<OWNED> {
 }
 impl<const OWNED: bool> From<ListBoxIsOwned<OWNED>> for ControlIsOwned<OWNED> {
     fn from(o: ListBoxIsOwned<OWNED>) -> Self {
-        unsafe { ControlIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<ListBoxIsOwned<OWNED>> for WindowIsOwned<OWNED> {
     fn from(o: ListBoxIsOwned<OWNED>) -> Self {
-        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<ListBoxIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
     fn from(o: ListBoxIsOwned<OWNED>) -> Self {
-        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<ListBoxIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
     fn from(o: ListBoxIsOwned<OWNED>) -> Self {
-        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for ListBoxIsOwned<OWNED> {
@@ -2306,12 +2306,12 @@ impl<const OWNED: bool> MenuIsOwned<OWNED> {
 }
 impl<const OWNED: bool> From<MenuIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
     fn from(o: MenuIsOwned<OWNED>) -> Self {
-        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<MenuIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
     fn from(o: MenuIsOwned<OWNED>) -> Self {
-        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for MenuIsOwned<OWNED> {
@@ -2339,17 +2339,17 @@ impl<const OWNED: bool> MenuBarIsOwned<OWNED> {
 }
 impl<const OWNED: bool> From<MenuBarIsOwned<OWNED>> for WindowIsOwned<OWNED> {
     fn from(o: MenuBarIsOwned<OWNED>) -> Self {
-        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<MenuBarIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
     fn from(o: MenuBarIsOwned<OWNED>) -> Self {
-        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<MenuBarIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
     fn from(o: MenuBarIsOwned<OWNED>) -> Self {
-        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for MenuBarIsOwned<OWNED> {
@@ -2402,7 +2402,7 @@ impl<const OWNED: bool> MenuItemIsOwned<OWNED> {
 }
 impl<const OWNED: bool> From<MenuItemIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
     fn from(o: MenuItemIsOwned<OWNED>) -> Self {
-        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for MenuItemIsOwned<OWNED> {
@@ -2433,17 +2433,17 @@ impl<const OWNED: bool> NonOwnedWindowIsOwned<OWNED> {
 }
 impl<const OWNED: bool> From<NonOwnedWindowIsOwned<OWNED>> for WindowIsOwned<OWNED> {
     fn from(o: NonOwnedWindowIsOwned<OWNED>) -> Self {
-        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<NonOwnedWindowIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
     fn from(o: NonOwnedWindowIsOwned<OWNED>) -> Self {
-        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<NonOwnedWindowIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
     fn from(o: NonOwnedWindowIsOwned<OWNED>) -> Self {
-        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for NonOwnedWindowIsOwned<OWNED> {
@@ -2492,27 +2492,27 @@ impl<const OWNED: bool> NotebookIsOwned<OWNED> {
 }
 impl<const OWNED: bool> From<NotebookIsOwned<OWNED>> for BookCtrlBaseIsOwned<OWNED> {
     fn from(o: NotebookIsOwned<OWNED>) -> Self {
-        unsafe { BookCtrlBaseIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<NotebookIsOwned<OWNED>> for ControlIsOwned<OWNED> {
     fn from(o: NotebookIsOwned<OWNED>) -> Self {
-        unsafe { ControlIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<NotebookIsOwned<OWNED>> for WindowIsOwned<OWNED> {
     fn from(o: NotebookIsOwned<OWNED>) -> Self {
-        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<NotebookIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
     fn from(o: NotebookIsOwned<OWNED>) -> Self {
-        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<NotebookIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
     fn from(o: NotebookIsOwned<OWNED>) -> Self {
-        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for NotebookIsOwned<OWNED> {
@@ -2543,17 +2543,17 @@ impl<const OWNED: bool> NotifyEventIsOwned<OWNED> {
 }
 impl<const OWNED: bool> From<NotifyEventIsOwned<OWNED>> for CommandEventIsOwned<OWNED> {
     fn from(o: NotifyEventIsOwned<OWNED>) -> Self {
-        unsafe { CommandEventIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<NotifyEventIsOwned<OWNED>> for EventIsOwned<OWNED> {
     fn from(o: NotifyEventIsOwned<OWNED>) -> Self {
-        unsafe { EventIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<NotifyEventIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
     fn from(o: NotifyEventIsOwned<OWNED>) -> Self {
-        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for NotifyEventIsOwned<OWNED> {
@@ -2607,17 +2607,17 @@ impl<const OWNED: bool> PanelIsOwned<OWNED> {
 }
 impl<const OWNED: bool> From<PanelIsOwned<OWNED>> for WindowIsOwned<OWNED> {
     fn from(o: PanelIsOwned<OWNED>) -> Self {
-        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<PanelIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
     fn from(o: PanelIsOwned<OWNED>) -> Self {
-        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<PanelIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
     fn from(o: PanelIsOwned<OWNED>) -> Self {
-        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for PanelIsOwned<OWNED> {
@@ -2666,22 +2666,22 @@ impl<const OWNED: bool> PickerBaseIsOwned<OWNED> {
 }
 impl<const OWNED: bool> From<PickerBaseIsOwned<OWNED>> for ControlIsOwned<OWNED> {
     fn from(o: PickerBaseIsOwned<OWNED>) -> Self {
-        unsafe { ControlIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<PickerBaseIsOwned<OWNED>> for WindowIsOwned<OWNED> {
     fn from(o: PickerBaseIsOwned<OWNED>) -> Self {
-        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<PickerBaseIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
     fn from(o: PickerBaseIsOwned<OWNED>) -> Self {
-        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<PickerBaseIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
     fn from(o: PickerBaseIsOwned<OWNED>) -> Self {
-        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for PickerBaseIsOwned<OWNED> {
@@ -2782,22 +2782,22 @@ impl<const OWNED: bool> RadioBoxIsOwned<OWNED> {
 }
 impl<const OWNED: bool> From<RadioBoxIsOwned<OWNED>> for ControlIsOwned<OWNED> {
     fn from(o: RadioBoxIsOwned<OWNED>) -> Self {
-        unsafe { ControlIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<RadioBoxIsOwned<OWNED>> for WindowIsOwned<OWNED> {
     fn from(o: RadioBoxIsOwned<OWNED>) -> Self {
-        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<RadioBoxIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
     fn from(o: RadioBoxIsOwned<OWNED>) -> Self {
-        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<RadioBoxIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
     fn from(o: RadioBoxIsOwned<OWNED>) -> Self {
-        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for RadioBoxIsOwned<OWNED> {
@@ -2875,7 +2875,7 @@ impl<const OWNED: bool> SettableHeaderColumnIsOwned<OWNED> {
 }
 impl<const OWNED: bool> From<SettableHeaderColumnIsOwned<OWNED>> for HeaderColumnIsOwned<OWNED> {
     fn from(o: SettableHeaderColumnIsOwned<OWNED>) -> Self {
-        unsafe { HeaderColumnIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> Drop for SettableHeaderColumnIsOwned<OWNED> {
@@ -2924,7 +2924,7 @@ impl<const OWNED: bool> SizerIsOwned<OWNED> {
 }
 impl<const OWNED: bool> From<SizerIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
     fn from(o: SizerIsOwned<OWNED>) -> Self {
-        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for SizerIsOwned<OWNED> {
@@ -3003,22 +3003,22 @@ impl<const OWNED: bool> StaticBitmapIsOwned<OWNED> {
 }
 impl<const OWNED: bool> From<StaticBitmapIsOwned<OWNED>> for ControlIsOwned<OWNED> {
     fn from(o: StaticBitmapIsOwned<OWNED>) -> Self {
-        unsafe { ControlIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<StaticBitmapIsOwned<OWNED>> for WindowIsOwned<OWNED> {
     fn from(o: StaticBitmapIsOwned<OWNED>) -> Self {
-        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<StaticBitmapIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
     fn from(o: StaticBitmapIsOwned<OWNED>) -> Self {
-        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<StaticBitmapIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
     fn from(o: StaticBitmapIsOwned<OWNED>) -> Self {
-        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for StaticBitmapIsOwned<OWNED> {
@@ -3072,22 +3072,22 @@ impl<const OWNED: bool> StaticBoxIsOwned<OWNED> {
 }
 impl<const OWNED: bool> From<StaticBoxIsOwned<OWNED>> for ControlIsOwned<OWNED> {
     fn from(o: StaticBoxIsOwned<OWNED>) -> Self {
-        unsafe { ControlIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<StaticBoxIsOwned<OWNED>> for WindowIsOwned<OWNED> {
     fn from(o: StaticBoxIsOwned<OWNED>) -> Self {
-        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<StaticBoxIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
     fn from(o: StaticBoxIsOwned<OWNED>) -> Self {
-        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<StaticBoxIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
     fn from(o: StaticBoxIsOwned<OWNED>) -> Self {
-        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for StaticBoxIsOwned<OWNED> {
@@ -3138,17 +3138,17 @@ impl<const OWNED: bool> StaticBoxSizerIsOwned<OWNED> {
 }
 impl<const OWNED: bool> From<StaticBoxSizerIsOwned<OWNED>> for BoxSizerIsOwned<OWNED> {
     fn from(o: StaticBoxSizerIsOwned<OWNED>) -> Self {
-        unsafe { BoxSizerIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<StaticBoxSizerIsOwned<OWNED>> for SizerIsOwned<OWNED> {
     fn from(o: StaticBoxSizerIsOwned<OWNED>) -> Self {
-        unsafe { SizerIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<StaticBoxSizerIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
     fn from(o: StaticBoxSizerIsOwned<OWNED>) -> Self {
-        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for StaticBoxSizerIsOwned<OWNED> {
@@ -3201,22 +3201,22 @@ impl<const OWNED: bool> StaticTextIsOwned<OWNED> {
 }
 impl<const OWNED: bool> From<StaticTextIsOwned<OWNED>> for ControlIsOwned<OWNED> {
     fn from(o: StaticTextIsOwned<OWNED>) -> Self {
-        unsafe { ControlIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<StaticTextIsOwned<OWNED>> for WindowIsOwned<OWNED> {
     fn from(o: StaticTextIsOwned<OWNED>) -> Self {
-        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<StaticTextIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
     fn from(o: StaticTextIsOwned<OWNED>) -> Self {
-        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<StaticTextIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
     fn from(o: StaticTextIsOwned<OWNED>) -> Self {
-        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for StaticTextIsOwned<OWNED> {
@@ -3299,22 +3299,22 @@ impl<const OWNED: bool> TextCtrlIsOwned<OWNED> {
 }
 impl<const OWNED: bool> From<TextCtrlIsOwned<OWNED>> for ControlIsOwned<OWNED> {
     fn from(o: TextCtrlIsOwned<OWNED>) -> Self {
-        unsafe { ControlIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<TextCtrlIsOwned<OWNED>> for WindowIsOwned<OWNED> {
     fn from(o: TextCtrlIsOwned<OWNED>) -> Self {
-        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<TextCtrlIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
     fn from(o: TextCtrlIsOwned<OWNED>) -> Self {
-        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<TextCtrlIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
     fn from(o: TextCtrlIsOwned<OWNED>) -> Self {
-        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for TextCtrlIsOwned<OWNED> {
@@ -3370,22 +3370,22 @@ impl<const OWNED: bool> ToolBarIsOwned<OWNED> {
 }
 impl<const OWNED: bool> From<ToolBarIsOwned<OWNED>> for ControlIsOwned<OWNED> {
     fn from(o: ToolBarIsOwned<OWNED>) -> Self {
-        unsafe { ControlIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<ToolBarIsOwned<OWNED>> for WindowIsOwned<OWNED> {
     fn from(o: ToolBarIsOwned<OWNED>) -> Self {
-        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<ToolBarIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
     fn from(o: ToolBarIsOwned<OWNED>) -> Self {
-        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<ToolBarIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
     fn from(o: ToolBarIsOwned<OWNED>) -> Self {
-        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for ToolBarIsOwned<OWNED> {
@@ -3438,22 +3438,22 @@ impl<const OWNED: bool> TopLevelWindowIsOwned<OWNED> {
 }
 impl<const OWNED: bool> From<TopLevelWindowIsOwned<OWNED>> for NonOwnedWindowIsOwned<OWNED> {
     fn from(o: TopLevelWindowIsOwned<OWNED>) -> Self {
-        unsafe { NonOwnedWindowIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<TopLevelWindowIsOwned<OWNED>> for WindowIsOwned<OWNED> {
     fn from(o: TopLevelWindowIsOwned<OWNED>) -> Self {
-        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<TopLevelWindowIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
     fn from(o: TopLevelWindowIsOwned<OWNED>) -> Self {
-        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<TopLevelWindowIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
     fn from(o: TopLevelWindowIsOwned<OWNED>) -> Self {
-        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for TopLevelWindowIsOwned<OWNED> {
@@ -3479,12 +3479,12 @@ impl<const OWNED: bool> ValidatorIsOwned<OWNED> {
 }
 impl<const OWNED: bool> From<ValidatorIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
     fn from(o: ValidatorIsOwned<OWNED>) -> Self {
-        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<ValidatorIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
     fn from(o: ValidatorIsOwned<OWNED>) -> Self {
-        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for ValidatorIsOwned<OWNED> {
@@ -3530,12 +3530,12 @@ impl<const OWNED: bool> WindowIsOwned<OWNED> {
 }
 impl<const OWNED: bool> From<WindowIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
     fn from(o: WindowIsOwned<OWNED>) -> Self {
-        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<WindowIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
     fn from(o: WindowIsOwned<OWNED>) -> Self {
-        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for WindowIsOwned<OWNED> {
@@ -3562,17 +3562,17 @@ impl<const OWNED: bool> WrapSizerIsOwned<OWNED> {
 }
 impl<const OWNED: bool> From<WrapSizerIsOwned<OWNED>> for BoxSizerIsOwned<OWNED> {
     fn from(o: WrapSizerIsOwned<OWNED>) -> Self {
-        unsafe { BoxSizerIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<WrapSizerIsOwned<OWNED>> for SizerIsOwned<OWNED> {
     fn from(o: WrapSizerIsOwned<OWNED>) -> Self {
-        unsafe { SizerIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> From<WrapSizerIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
     fn from(o: WrapSizerIsOwned<OWNED>) -> Self {
-        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+        unsafe { Self::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for WrapSizerIsOwned<OWNED> {

--- a/wx-core/src/generated.rs
+++ b/wx-core/src/generated.rs
@@ -488,6 +488,11 @@ impl<const OWNED: bool> ListBoxMethods for CheckListBoxIsOwned<OWNED> {
         }
     }
 }
+impl<const OWNED: bool> From<CheckListBoxIsOwned<OWNED>> for ListBoxIsOwned<OWNED> {
+    fn from(o: CheckListBoxIsOwned<OWNED>) -> Self {
+        unsafe { ListBoxIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
 
 // wxChoice
 wx_class! { Choice =

--- a/wx-core/src/generated.rs
+++ b/wx-core/src/generated.rs
@@ -32,6 +32,26 @@ impl<const OWNED: bool> AnyButtonIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> From<AnyButtonIsOwned<OWNED>> for ControlIsOwned<OWNED> {
+    fn from(o: AnyButtonIsOwned<OWNED>) -> Self {
+        unsafe { ControlIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<AnyButtonIsOwned<OWNED>> for WindowIsOwned<OWNED> {
+    fn from(o: AnyButtonIsOwned<OWNED>) -> Self {
+        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<AnyButtonIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
+    fn from(o: AnyButtonIsOwned<OWNED>) -> Self {
+        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<AnyButtonIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
+    fn from(o: AnyButtonIsOwned<OWNED>) -> Self {
+        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
 impl<const OWNED: bool> DynamicCast for AnyButtonIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxAnyButton_CLASSINFO()) }
@@ -47,6 +67,11 @@ wx_class! { ArtProvider =
 impl<const OWNED: bool> ArtProviderIsOwned<OWNED> {
     pub fn none() -> Option<&'static Self> {
         None
+    }
+}
+impl<const OWNED: bool> From<ArtProviderIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
+    fn from(o: ArtProviderIsOwned<OWNED>) -> Self {
+        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for ArtProviderIsOwned<OWNED> {
@@ -107,6 +132,16 @@ impl<const OWNED: bool> BitmapIsOwned<OWNED> {
     }
     pub fn none() -> Option<&'static Self> {
         None
+    }
+}
+impl<const OWNED: bool> From<BitmapIsOwned<OWNED>> for GDIObjectIsOwned<OWNED> {
+    fn from(o: BitmapIsOwned<OWNED>) -> Self {
+        unsafe { GDIObjectIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<BitmapIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
+    fn from(o: BitmapIsOwned<OWNED>) -> Self {
+        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for BitmapIsOwned<OWNED> {
@@ -218,6 +253,36 @@ impl<const OWNED: bool> BitmapButtonIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> From<BitmapButtonIsOwned<OWNED>> for ButtonIsOwned<OWNED> {
+    fn from(o: BitmapButtonIsOwned<OWNED>) -> Self {
+        unsafe { ButtonIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<BitmapButtonIsOwned<OWNED>> for AnyButtonIsOwned<OWNED> {
+    fn from(o: BitmapButtonIsOwned<OWNED>) -> Self {
+        unsafe { AnyButtonIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<BitmapButtonIsOwned<OWNED>> for ControlIsOwned<OWNED> {
+    fn from(o: BitmapButtonIsOwned<OWNED>) -> Self {
+        unsafe { ControlIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<BitmapButtonIsOwned<OWNED>> for WindowIsOwned<OWNED> {
+    fn from(o: BitmapButtonIsOwned<OWNED>) -> Self {
+        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<BitmapButtonIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
+    fn from(o: BitmapButtonIsOwned<OWNED>) -> Self {
+        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<BitmapButtonIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
+    fn from(o: BitmapButtonIsOwned<OWNED>) -> Self {
+        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
 impl<const OWNED: bool> DynamicCast for BitmapButtonIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxBitmapButton_CLASSINFO()) }
@@ -241,6 +306,26 @@ impl<const OWNED: bool> BookCtrlBaseIsOwned<OWNED> {
     // BLOCKED: fn wxBookCtrlBase1()
     pub fn none() -> Option<&'static Self> {
         None
+    }
+}
+impl<const OWNED: bool> From<BookCtrlBaseIsOwned<OWNED>> for ControlIsOwned<OWNED> {
+    fn from(o: BookCtrlBaseIsOwned<OWNED>) -> Self {
+        unsafe { ControlIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<BookCtrlBaseIsOwned<OWNED>> for WindowIsOwned<OWNED> {
+    fn from(o: BookCtrlBaseIsOwned<OWNED>) -> Self {
+        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<BookCtrlBaseIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
+    fn from(o: BookCtrlBaseIsOwned<OWNED>) -> Self {
+        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<BookCtrlBaseIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
+    fn from(o: BookCtrlBaseIsOwned<OWNED>) -> Self {
+        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for BookCtrlBaseIsOwned<OWNED> {
@@ -287,6 +372,26 @@ impl<const OWNED: bool> BookCtrlEventIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> From<BookCtrlEventIsOwned<OWNED>> for NotifyEventIsOwned<OWNED> {
+    fn from(o: BookCtrlEventIsOwned<OWNED>) -> Self {
+        unsafe { NotifyEventIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<BookCtrlEventIsOwned<OWNED>> for CommandEventIsOwned<OWNED> {
+    fn from(o: BookCtrlEventIsOwned<OWNED>) -> Self {
+        unsafe { CommandEventIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<BookCtrlEventIsOwned<OWNED>> for EventIsOwned<OWNED> {
+    fn from(o: BookCtrlEventIsOwned<OWNED>) -> Self {
+        unsafe { EventIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<BookCtrlEventIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
+    fn from(o: BookCtrlEventIsOwned<OWNED>) -> Self {
+        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
 impl<const OWNED: bool> DynamicCast for BookCtrlEventIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxBookCtrlEvent_CLASSINFO()) }
@@ -318,6 +423,16 @@ impl<const OWNED: bool> BoxSizerIsOwned<OWNED> {
     }
     pub fn none() -> Option<&'static Self> {
         None
+    }
+}
+impl<const OWNED: bool> From<BoxSizerIsOwned<OWNED>> for SizerIsOwned<OWNED> {
+    fn from(o: BoxSizerIsOwned<OWNED>) -> Self {
+        unsafe { SizerIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<BoxSizerIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
+    fn from(o: BoxSizerIsOwned<OWNED>) -> Self {
+        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for BoxSizerIsOwned<OWNED> {
@@ -371,6 +486,31 @@ impl<const OWNED: bool> ButtonIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> From<ButtonIsOwned<OWNED>> for AnyButtonIsOwned<OWNED> {
+    fn from(o: ButtonIsOwned<OWNED>) -> Self {
+        unsafe { AnyButtonIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<ButtonIsOwned<OWNED>> for ControlIsOwned<OWNED> {
+    fn from(o: ButtonIsOwned<OWNED>) -> Self {
+        unsafe { ControlIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<ButtonIsOwned<OWNED>> for WindowIsOwned<OWNED> {
+    fn from(o: ButtonIsOwned<OWNED>) -> Self {
+        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<ButtonIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
+    fn from(o: ButtonIsOwned<OWNED>) -> Self {
+        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<ButtonIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
+    fn from(o: ButtonIsOwned<OWNED>) -> Self {
+        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
 impl<const OWNED: bool> DynamicCast for ButtonIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxButton_CLASSINFO()) }
@@ -419,6 +559,26 @@ impl<const OWNED: bool> CheckBoxIsOwned<OWNED> {
     }
     pub fn none() -> Option<&'static Self> {
         None
+    }
+}
+impl<const OWNED: bool> From<CheckBoxIsOwned<OWNED>> for ControlIsOwned<OWNED> {
+    fn from(o: CheckBoxIsOwned<OWNED>) -> Self {
+        unsafe { ControlIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<CheckBoxIsOwned<OWNED>> for WindowIsOwned<OWNED> {
+    fn from(o: CheckBoxIsOwned<OWNED>) -> Self {
+        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<CheckBoxIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
+    fn from(o: CheckBoxIsOwned<OWNED>) -> Self {
+        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<CheckBoxIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
+    fn from(o: CheckBoxIsOwned<OWNED>) -> Self {
+        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for CheckBoxIsOwned<OWNED> {
@@ -476,6 +636,31 @@ impl<const OWNED: bool> CheckListBoxIsOwned<OWNED> {
     }
     pub fn none() -> Option<&'static Self> {
         None
+    }
+}
+impl<const OWNED: bool> From<CheckListBoxIsOwned<OWNED>> for ListBoxIsOwned<OWNED> {
+    fn from(o: CheckListBoxIsOwned<OWNED>) -> Self {
+        unsafe { ListBoxIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<CheckListBoxIsOwned<OWNED>> for ControlIsOwned<OWNED> {
+    fn from(o: CheckListBoxIsOwned<OWNED>) -> Self {
+        unsafe { ControlIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<CheckListBoxIsOwned<OWNED>> for WindowIsOwned<OWNED> {
+    fn from(o: CheckListBoxIsOwned<OWNED>) -> Self {
+        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<CheckListBoxIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
+    fn from(o: CheckListBoxIsOwned<OWNED>) -> Self {
+        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<CheckListBoxIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
+    fn from(o: CheckListBoxIsOwned<OWNED>) -> Self {
+        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for CheckListBoxIsOwned<OWNED> {
@@ -589,6 +774,26 @@ impl<const OWNED: bool> ChoiceIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> From<ChoiceIsOwned<OWNED>> for ControlIsOwned<OWNED> {
+    fn from(o: ChoiceIsOwned<OWNED>) -> Self {
+        unsafe { ControlIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<ChoiceIsOwned<OWNED>> for WindowIsOwned<OWNED> {
+    fn from(o: ChoiceIsOwned<OWNED>) -> Self {
+        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<ChoiceIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
+    fn from(o: ChoiceIsOwned<OWNED>) -> Self {
+        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<ChoiceIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
+    fn from(o: ChoiceIsOwned<OWNED>) -> Self {
+        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
 impl<const OWNED: bool> DynamicCast for ChoiceIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxChoice_CLASSINFO()) }
@@ -633,6 +838,11 @@ impl<const OWNED: bool> ColourIsOwned<OWNED> {
     }
     pub fn none() -> Option<&'static Self> {
         None
+    }
+}
+impl<const OWNED: bool> From<ColourIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
+    fn from(o: ColourIsOwned<OWNED>) -> Self {
+        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for ColourIsOwned<OWNED> {
@@ -698,6 +908,31 @@ impl<const OWNED: bool> ColourPickerCtrlIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> From<ColourPickerCtrlIsOwned<OWNED>> for PickerBaseIsOwned<OWNED> {
+    fn from(o: ColourPickerCtrlIsOwned<OWNED>) -> Self {
+        unsafe { PickerBaseIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<ColourPickerCtrlIsOwned<OWNED>> for ControlIsOwned<OWNED> {
+    fn from(o: ColourPickerCtrlIsOwned<OWNED>) -> Self {
+        unsafe { ControlIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<ColourPickerCtrlIsOwned<OWNED>> for WindowIsOwned<OWNED> {
+    fn from(o: ColourPickerCtrlIsOwned<OWNED>) -> Self {
+        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<ColourPickerCtrlIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
+    fn from(o: ColourPickerCtrlIsOwned<OWNED>) -> Self {
+        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<ColourPickerCtrlIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
+    fn from(o: ColourPickerCtrlIsOwned<OWNED>) -> Self {
+        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
 impl<const OWNED: bool> DynamicCast for ColourPickerCtrlIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxColourPickerCtrl_CLASSINFO()) }
@@ -757,6 +992,26 @@ impl<const OWNED: bool> ComboBoxIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> From<ComboBoxIsOwned<OWNED>> for ControlIsOwned<OWNED> {
+    fn from(o: ComboBoxIsOwned<OWNED>) -> Self {
+        unsafe { ControlIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<ComboBoxIsOwned<OWNED>> for WindowIsOwned<OWNED> {
+    fn from(o: ComboBoxIsOwned<OWNED>) -> Self {
+        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<ComboBoxIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
+    fn from(o: ComboBoxIsOwned<OWNED>) -> Self {
+        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<ComboBoxIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
+    fn from(o: ComboBoxIsOwned<OWNED>) -> Self {
+        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
 impl<const OWNED: bool> DynamicCast for ComboBoxIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxComboBox_CLASSINFO()) }
@@ -790,6 +1045,16 @@ impl<const OWNED: bool> CommandEventIsOwned<OWNED> {
     // NOT_SUPPORTED: fn wxCommandEvent()
     pub fn none() -> Option<&'static Self> {
         None
+    }
+}
+impl<const OWNED: bool> From<CommandEventIsOwned<OWNED>> for EventIsOwned<OWNED> {
+    fn from(o: CommandEventIsOwned<OWNED>) -> Self {
+        unsafe { EventIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<CommandEventIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
+    fn from(o: CommandEventIsOwned<OWNED>) -> Self {
+        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for CommandEventIsOwned<OWNED> {
@@ -843,6 +1108,21 @@ impl<const OWNED: bool> ControlIsOwned<OWNED> {
     }
     pub fn none() -> Option<&'static Self> {
         None
+    }
+}
+impl<const OWNED: bool> From<ControlIsOwned<OWNED>> for WindowIsOwned<OWNED> {
+    fn from(o: ControlIsOwned<OWNED>) -> Self {
+        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<ControlIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
+    fn from(o: ControlIsOwned<OWNED>) -> Self {
+        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<ControlIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
+    fn from(o: ControlIsOwned<OWNED>) -> Self {
+        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for ControlIsOwned<OWNED> {
@@ -900,6 +1180,26 @@ impl<const OWNED: bool> DatePickerCtrlIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> From<DatePickerCtrlIsOwned<OWNED>> for ControlIsOwned<OWNED> {
+    fn from(o: DatePickerCtrlIsOwned<OWNED>) -> Self {
+        unsafe { ControlIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<DatePickerCtrlIsOwned<OWNED>> for WindowIsOwned<OWNED> {
+    fn from(o: DatePickerCtrlIsOwned<OWNED>) -> Self {
+        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<DatePickerCtrlIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
+    fn from(o: DatePickerCtrlIsOwned<OWNED>) -> Self {
+        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<DatePickerCtrlIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
+    fn from(o: DatePickerCtrlIsOwned<OWNED>) -> Self {
+        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
 impl<const OWNED: bool> DynamicCast for DatePickerCtrlIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxDatePickerCtrl_CLASSINFO()) }
@@ -954,6 +1254,31 @@ impl<const OWNED: bool> DirPickerCtrlIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> From<DirPickerCtrlIsOwned<OWNED>> for PickerBaseIsOwned<OWNED> {
+    fn from(o: DirPickerCtrlIsOwned<OWNED>) -> Self {
+        unsafe { PickerBaseIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<DirPickerCtrlIsOwned<OWNED>> for ControlIsOwned<OWNED> {
+    fn from(o: DirPickerCtrlIsOwned<OWNED>) -> Self {
+        unsafe { ControlIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<DirPickerCtrlIsOwned<OWNED>> for WindowIsOwned<OWNED> {
+    fn from(o: DirPickerCtrlIsOwned<OWNED>) -> Self {
+        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<DirPickerCtrlIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
+    fn from(o: DirPickerCtrlIsOwned<OWNED>) -> Self {
+        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<DirPickerCtrlIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
+    fn from(o: DirPickerCtrlIsOwned<OWNED>) -> Self {
+        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
 impl<const OWNED: bool> DynamicCast for DirPickerCtrlIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxDirPickerCtrl_CLASSINFO()) }
@@ -1000,6 +1325,26 @@ impl<const OWNED: bool> EditableListBoxIsOwned<OWNED> {
     }
     pub fn none() -> Option<&'static Self> {
         None
+    }
+}
+impl<const OWNED: bool> From<EditableListBoxIsOwned<OWNED>> for PanelIsOwned<OWNED> {
+    fn from(o: EditableListBoxIsOwned<OWNED>) -> Self {
+        unsafe { PanelIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<EditableListBoxIsOwned<OWNED>> for WindowIsOwned<OWNED> {
+    fn from(o: EditableListBoxIsOwned<OWNED>) -> Self {
+        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<EditableListBoxIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
+    fn from(o: EditableListBoxIsOwned<OWNED>) -> Self {
+        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<EditableListBoxIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
+    fn from(o: EditableListBoxIsOwned<OWNED>) -> Self {
+        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for EditableListBoxIsOwned<OWNED> {
@@ -1064,6 +1409,26 @@ impl<const OWNED: bool> FileCtrlIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> From<FileCtrlIsOwned<OWNED>> for ControlIsOwned<OWNED> {
+    fn from(o: FileCtrlIsOwned<OWNED>) -> Self {
+        unsafe { ControlIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<FileCtrlIsOwned<OWNED>> for WindowIsOwned<OWNED> {
+    fn from(o: FileCtrlIsOwned<OWNED>) -> Self {
+        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<FileCtrlIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
+    fn from(o: FileCtrlIsOwned<OWNED>) -> Self {
+        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<FileCtrlIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
+    fn from(o: FileCtrlIsOwned<OWNED>) -> Self {
+        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
 impl<const OWNED: bool> DynamicCast for FileCtrlIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxFileCtrl_CLASSINFO()) }
@@ -1104,6 +1469,16 @@ impl<const OWNED: bool> FontIsOwned<OWNED> {
     }
     pub fn none() -> Option<&'static Self> {
         None
+    }
+}
+impl<const OWNED: bool> From<FontIsOwned<OWNED>> for GDIObjectIsOwned<OWNED> {
+    fn from(o: FontIsOwned<OWNED>) -> Self {
+        unsafe { GDIObjectIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<FontIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
+    fn from(o: FontIsOwned<OWNED>) -> Self {
+        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for FontIsOwned<OWNED> {
@@ -1169,6 +1544,31 @@ impl<const OWNED: bool> FontPickerCtrlIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> From<FontPickerCtrlIsOwned<OWNED>> for PickerBaseIsOwned<OWNED> {
+    fn from(o: FontPickerCtrlIsOwned<OWNED>) -> Self {
+        unsafe { PickerBaseIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<FontPickerCtrlIsOwned<OWNED>> for ControlIsOwned<OWNED> {
+    fn from(o: FontPickerCtrlIsOwned<OWNED>) -> Self {
+        unsafe { ControlIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<FontPickerCtrlIsOwned<OWNED>> for WindowIsOwned<OWNED> {
+    fn from(o: FontPickerCtrlIsOwned<OWNED>) -> Self {
+        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<FontPickerCtrlIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
+    fn from(o: FontPickerCtrlIsOwned<OWNED>) -> Self {
+        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<FontPickerCtrlIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
+    fn from(o: FontPickerCtrlIsOwned<OWNED>) -> Self {
+        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
 impl<const OWNED: bool> DynamicCast for FontPickerCtrlIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxFontPickerCtrl_CLASSINFO()) }
@@ -1214,6 +1614,31 @@ impl<const OWNED: bool> FrameIsOwned<OWNED> {
     }
     pub fn none() -> Option<&'static Self> {
         None
+    }
+}
+impl<const OWNED: bool> From<FrameIsOwned<OWNED>> for TopLevelWindowIsOwned<OWNED> {
+    fn from(o: FrameIsOwned<OWNED>) -> Self {
+        unsafe { TopLevelWindowIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<FrameIsOwned<OWNED>> for NonOwnedWindowIsOwned<OWNED> {
+    fn from(o: FrameIsOwned<OWNED>) -> Self {
+        unsafe { NonOwnedWindowIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<FrameIsOwned<OWNED>> for WindowIsOwned<OWNED> {
+    fn from(o: FrameIsOwned<OWNED>) -> Self {
+        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<FrameIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
+    fn from(o: FrameIsOwned<OWNED>) -> Self {
+        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<FrameIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
+    fn from(o: FrameIsOwned<OWNED>) -> Self {
+        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for FrameIsOwned<OWNED> {
@@ -1263,6 +1688,11 @@ impl<const OWNED: bool> GDIObjectIsOwned<OWNED> {
     // BLOCKED: fn wxGDIObject()
     pub fn none() -> Option<&'static Self> {
         None
+    }
+}
+impl<const OWNED: bool> From<GDIObjectIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
+    fn from(o: GDIObjectIsOwned<OWNED>) -> Self {
+        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for GDIObjectIsOwned<OWNED> {
@@ -1318,6 +1748,26 @@ impl<const OWNED: bool> GaugeIsOwned<OWNED> {
     }
     pub fn none() -> Option<&'static Self> {
         None
+    }
+}
+impl<const OWNED: bool> From<GaugeIsOwned<OWNED>> for ControlIsOwned<OWNED> {
+    fn from(o: GaugeIsOwned<OWNED>) -> Self {
+        unsafe { ControlIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<GaugeIsOwned<OWNED>> for WindowIsOwned<OWNED> {
+    fn from(o: GaugeIsOwned<OWNED>) -> Self {
+        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<GaugeIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
+    fn from(o: GaugeIsOwned<OWNED>) -> Self {
+        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<GaugeIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
+    fn from(o: GaugeIsOwned<OWNED>) -> Self {
+        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for GaugeIsOwned<OWNED> {
@@ -1380,6 +1830,26 @@ impl<const OWNED: bool> GenericDirCtrlIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> From<GenericDirCtrlIsOwned<OWNED>> for ControlIsOwned<OWNED> {
+    fn from(o: GenericDirCtrlIsOwned<OWNED>) -> Self {
+        unsafe { ControlIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<GenericDirCtrlIsOwned<OWNED>> for WindowIsOwned<OWNED> {
+    fn from(o: GenericDirCtrlIsOwned<OWNED>) -> Self {
+        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<GenericDirCtrlIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
+    fn from(o: GenericDirCtrlIsOwned<OWNED>) -> Self {
+        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<GenericDirCtrlIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
+    fn from(o: GenericDirCtrlIsOwned<OWNED>) -> Self {
+        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
 impl<const OWNED: bool> DynamicCast for GenericDirCtrlIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxGenericDirCtrl_CLASSINFO()) }
@@ -1439,6 +1909,18 @@ impl<const OWNED: bool> HeaderColumnSimpleIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> From<HeaderColumnSimpleIsOwned<OWNED>>
+    for SettableHeaderColumnIsOwned<OWNED>
+{
+    fn from(o: HeaderColumnSimpleIsOwned<OWNED>) -> Self {
+        unsafe { SettableHeaderColumnIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<HeaderColumnSimpleIsOwned<OWNED>> for HeaderColumnIsOwned<OWNED> {
+    fn from(o: HeaderColumnSimpleIsOwned<OWNED>) -> Self {
+        unsafe { HeaderColumnIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
 impl<const OWNED: bool> Drop for HeaderColumnSimpleIsOwned<OWNED> {
     fn drop(&mut self) {
         if OWNED {
@@ -1461,6 +1943,26 @@ impl<const OWNED: bool> HeaderCtrlIsOwned<OWNED> {
     // BLOCKED: fn wxHeaderCtrl1()
     pub fn none() -> Option<&'static Self> {
         None
+    }
+}
+impl<const OWNED: bool> From<HeaderCtrlIsOwned<OWNED>> for ControlIsOwned<OWNED> {
+    fn from(o: HeaderCtrlIsOwned<OWNED>) -> Self {
+        unsafe { ControlIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<HeaderCtrlIsOwned<OWNED>> for WindowIsOwned<OWNED> {
+    fn from(o: HeaderCtrlIsOwned<OWNED>) -> Self {
+        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<HeaderCtrlIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
+    fn from(o: HeaderCtrlIsOwned<OWNED>) -> Self {
+        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<HeaderCtrlIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
+    fn from(o: HeaderCtrlIsOwned<OWNED>) -> Self {
+        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for HeaderCtrlIsOwned<OWNED> {
@@ -1532,6 +2034,31 @@ impl<const OWNED: bool> HeaderCtrlSimpleIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> From<HeaderCtrlSimpleIsOwned<OWNED>> for HeaderCtrlIsOwned<OWNED> {
+    fn from(o: HeaderCtrlSimpleIsOwned<OWNED>) -> Self {
+        unsafe { HeaderCtrlIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<HeaderCtrlSimpleIsOwned<OWNED>> for ControlIsOwned<OWNED> {
+    fn from(o: HeaderCtrlSimpleIsOwned<OWNED>) -> Self {
+        unsafe { ControlIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<HeaderCtrlSimpleIsOwned<OWNED>> for WindowIsOwned<OWNED> {
+    fn from(o: HeaderCtrlSimpleIsOwned<OWNED>) -> Self {
+        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<HeaderCtrlSimpleIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
+    fn from(o: HeaderCtrlSimpleIsOwned<OWNED>) -> Self {
+        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<HeaderCtrlSimpleIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
+    fn from(o: HeaderCtrlSimpleIsOwned<OWNED>) -> Self {
+        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
 impl<const OWNED: bool> DynamicCast for HeaderCtrlSimpleIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxHeaderCtrlSimple_CLASSINFO()) }
@@ -1583,6 +2110,26 @@ impl<const OWNED: bool> HyperlinkCtrlIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> From<HyperlinkCtrlIsOwned<OWNED>> for ControlIsOwned<OWNED> {
+    fn from(o: HyperlinkCtrlIsOwned<OWNED>) -> Self {
+        unsafe { ControlIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<HyperlinkCtrlIsOwned<OWNED>> for WindowIsOwned<OWNED> {
+    fn from(o: HyperlinkCtrlIsOwned<OWNED>) -> Self {
+        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<HyperlinkCtrlIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
+    fn from(o: HyperlinkCtrlIsOwned<OWNED>) -> Self {
+        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<HyperlinkCtrlIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
+    fn from(o: HyperlinkCtrlIsOwned<OWNED>) -> Self {
+        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
 impl<const OWNED: bool> DynamicCast for HyperlinkCtrlIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxHyperlinkCtrl_CLASSINFO()) }
@@ -1616,6 +2163,16 @@ impl<const OWNED: bool> IconIsOwned<OWNED> {
     }
     pub fn none() -> Option<&'static Self> {
         None
+    }
+}
+impl<const OWNED: bool> From<IconIsOwned<OWNED>> for GDIObjectIsOwned<OWNED> {
+    fn from(o: IconIsOwned<OWNED>) -> Self {
+        unsafe { GDIObjectIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<IconIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
+    fn from(o: IconIsOwned<OWNED>) -> Self {
+        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for IconIsOwned<OWNED> {
@@ -1685,6 +2242,26 @@ impl<const OWNED: bool> ListBoxIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> From<ListBoxIsOwned<OWNED>> for ControlIsOwned<OWNED> {
+    fn from(o: ListBoxIsOwned<OWNED>) -> Self {
+        unsafe { ControlIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<ListBoxIsOwned<OWNED>> for WindowIsOwned<OWNED> {
+    fn from(o: ListBoxIsOwned<OWNED>) -> Self {
+        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<ListBoxIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
+    fn from(o: ListBoxIsOwned<OWNED>) -> Self {
+        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<ListBoxIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
+    fn from(o: ListBoxIsOwned<OWNED>) -> Self {
+        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
 impl<const OWNED: bool> DynamicCast for ListBoxIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxListBox_CLASSINFO()) }
@@ -1727,6 +2304,16 @@ impl<const OWNED: bool> MenuIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> From<MenuIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
+    fn from(o: MenuIsOwned<OWNED>) -> Self {
+        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<MenuIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
+    fn from(o: MenuIsOwned<OWNED>) -> Self {
+        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
 impl<const OWNED: bool> DynamicCast for MenuIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxMenu_CLASSINFO()) }
@@ -1748,6 +2335,21 @@ impl<const OWNED: bool> MenuBarIsOwned<OWNED> {
     // NOT_SUPPORTED: fn wxMenuBar1()
     pub fn none() -> Option<&'static Self> {
         None
+    }
+}
+impl<const OWNED: bool> From<MenuBarIsOwned<OWNED>> for WindowIsOwned<OWNED> {
+    fn from(o: MenuBarIsOwned<OWNED>) -> Self {
+        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<MenuBarIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
+    fn from(o: MenuBarIsOwned<OWNED>) -> Self {
+        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<MenuBarIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
+    fn from(o: MenuBarIsOwned<OWNED>) -> Self {
+        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for MenuBarIsOwned<OWNED> {
@@ -1798,6 +2400,11 @@ impl<const OWNED: bool> MenuItemIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> From<MenuItemIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
+    fn from(o: MenuItemIsOwned<OWNED>) -> Self {
+        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
 impl<const OWNED: bool> DynamicCast for MenuItemIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxMenuItem_CLASSINFO()) }
@@ -1822,6 +2429,21 @@ wx_class! { NonOwnedWindow =
 impl<const OWNED: bool> NonOwnedWindowIsOwned<OWNED> {
     pub fn none() -> Option<&'static Self> {
         None
+    }
+}
+impl<const OWNED: bool> From<NonOwnedWindowIsOwned<OWNED>> for WindowIsOwned<OWNED> {
+    fn from(o: NonOwnedWindowIsOwned<OWNED>) -> Self {
+        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<NonOwnedWindowIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
+    fn from(o: NonOwnedWindowIsOwned<OWNED>) -> Self {
+        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<NonOwnedWindowIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
+    fn from(o: NonOwnedWindowIsOwned<OWNED>) -> Self {
+        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for NonOwnedWindowIsOwned<OWNED> {
@@ -1868,6 +2490,31 @@ impl<const OWNED: bool> NotebookIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> From<NotebookIsOwned<OWNED>> for BookCtrlBaseIsOwned<OWNED> {
+    fn from(o: NotebookIsOwned<OWNED>) -> Self {
+        unsafe { BookCtrlBaseIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<NotebookIsOwned<OWNED>> for ControlIsOwned<OWNED> {
+    fn from(o: NotebookIsOwned<OWNED>) -> Self {
+        unsafe { ControlIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<NotebookIsOwned<OWNED>> for WindowIsOwned<OWNED> {
+    fn from(o: NotebookIsOwned<OWNED>) -> Self {
+        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<NotebookIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
+    fn from(o: NotebookIsOwned<OWNED>) -> Self {
+        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<NotebookIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
+    fn from(o: NotebookIsOwned<OWNED>) -> Self {
+        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
 impl<const OWNED: bool> DynamicCast for NotebookIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxNotebook_CLASSINFO()) }
@@ -1892,6 +2539,21 @@ impl<const OWNED: bool> NotifyEventIsOwned<OWNED> {
     // NOT_SUPPORTED: fn wxNotifyEvent()
     pub fn none() -> Option<&'static Self> {
         None
+    }
+}
+impl<const OWNED: bool> From<NotifyEventIsOwned<OWNED>> for CommandEventIsOwned<OWNED> {
+    fn from(o: NotifyEventIsOwned<OWNED>) -> Self {
+        unsafe { CommandEventIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<NotifyEventIsOwned<OWNED>> for EventIsOwned<OWNED> {
+    fn from(o: NotifyEventIsOwned<OWNED>) -> Self {
+        unsafe { EventIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<NotifyEventIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
+    fn from(o: NotifyEventIsOwned<OWNED>) -> Self {
+        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for NotifyEventIsOwned<OWNED> {
@@ -1943,6 +2605,21 @@ impl<const OWNED: bool> PanelIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> From<PanelIsOwned<OWNED>> for WindowIsOwned<OWNED> {
+    fn from(o: PanelIsOwned<OWNED>) -> Self {
+        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<PanelIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
+    fn from(o: PanelIsOwned<OWNED>) -> Self {
+        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<PanelIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
+    fn from(o: PanelIsOwned<OWNED>) -> Self {
+        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
 impl<const OWNED: bool> DynamicCast for PanelIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxPanel_CLASSINFO()) }
@@ -1985,6 +2662,26 @@ impl<const OWNED: bool> PickerBaseIsOwned<OWNED> {
     // BLOCKED: fn wxPickerBase()
     pub fn none() -> Option<&'static Self> {
         None
+    }
+}
+impl<const OWNED: bool> From<PickerBaseIsOwned<OWNED>> for ControlIsOwned<OWNED> {
+    fn from(o: PickerBaseIsOwned<OWNED>) -> Self {
+        unsafe { ControlIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<PickerBaseIsOwned<OWNED>> for WindowIsOwned<OWNED> {
+    fn from(o: PickerBaseIsOwned<OWNED>) -> Self {
+        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<PickerBaseIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
+    fn from(o: PickerBaseIsOwned<OWNED>) -> Self {
+        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<PickerBaseIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
+    fn from(o: PickerBaseIsOwned<OWNED>) -> Self {
+        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for PickerBaseIsOwned<OWNED> {
@@ -2083,6 +2780,26 @@ impl<const OWNED: bool> RadioBoxIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> From<RadioBoxIsOwned<OWNED>> for ControlIsOwned<OWNED> {
+    fn from(o: RadioBoxIsOwned<OWNED>) -> Self {
+        unsafe { ControlIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<RadioBoxIsOwned<OWNED>> for WindowIsOwned<OWNED> {
+    fn from(o: RadioBoxIsOwned<OWNED>) -> Self {
+        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<RadioBoxIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
+    fn from(o: RadioBoxIsOwned<OWNED>) -> Self {
+        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<RadioBoxIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
+    fn from(o: RadioBoxIsOwned<OWNED>) -> Self {
+        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
 impl<const OWNED: bool> DynamicCast for RadioBoxIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxRadioBox_CLASSINFO()) }
@@ -2156,6 +2873,11 @@ impl<const OWNED: bool> SettableHeaderColumnIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> From<SettableHeaderColumnIsOwned<OWNED>> for HeaderColumnIsOwned<OWNED> {
+    fn from(o: SettableHeaderColumnIsOwned<OWNED>) -> Self {
+        unsafe { HeaderColumnIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
 impl<const OWNED: bool> Drop for SettableHeaderColumnIsOwned<OWNED> {
     fn drop(&mut self) {
         if OWNED {
@@ -2198,6 +2920,11 @@ impl<const OWNED: bool> SizerIsOwned<OWNED> {
     // BLOCKED: fn wxSizer()
     pub fn none() -> Option<&'static Self> {
         None
+    }
+}
+impl<const OWNED: bool> From<SizerIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
+    fn from(o: SizerIsOwned<OWNED>) -> Self {
+        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for SizerIsOwned<OWNED> {
@@ -2274,6 +3001,26 @@ impl<const OWNED: bool> StaticBitmapIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> From<StaticBitmapIsOwned<OWNED>> for ControlIsOwned<OWNED> {
+    fn from(o: StaticBitmapIsOwned<OWNED>) -> Self {
+        unsafe { ControlIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<StaticBitmapIsOwned<OWNED>> for WindowIsOwned<OWNED> {
+    fn from(o: StaticBitmapIsOwned<OWNED>) -> Self {
+        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<StaticBitmapIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
+    fn from(o: StaticBitmapIsOwned<OWNED>) -> Self {
+        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<StaticBitmapIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
+    fn from(o: StaticBitmapIsOwned<OWNED>) -> Self {
+        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
 impl<const OWNED: bool> DynamicCast for StaticBitmapIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxStaticBitmap_CLASSINFO()) }
@@ -2323,6 +3070,26 @@ impl<const OWNED: bool> StaticBoxIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> From<StaticBoxIsOwned<OWNED>> for ControlIsOwned<OWNED> {
+    fn from(o: StaticBoxIsOwned<OWNED>) -> Self {
+        unsafe { ControlIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<StaticBoxIsOwned<OWNED>> for WindowIsOwned<OWNED> {
+    fn from(o: StaticBoxIsOwned<OWNED>) -> Self {
+        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<StaticBoxIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
+    fn from(o: StaticBoxIsOwned<OWNED>) -> Self {
+        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<StaticBoxIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
+    fn from(o: StaticBoxIsOwned<OWNED>) -> Self {
+        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
 impl<const OWNED: bool> DynamicCast for StaticBoxIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxStaticBox_CLASSINFO()) }
@@ -2367,6 +3134,21 @@ impl<const OWNED: bool> StaticBoxSizerIsOwned<OWNED> {
     }
     pub fn none() -> Option<&'static Self> {
         None
+    }
+}
+impl<const OWNED: bool> From<StaticBoxSizerIsOwned<OWNED>> for BoxSizerIsOwned<OWNED> {
+    fn from(o: StaticBoxSizerIsOwned<OWNED>) -> Self {
+        unsafe { BoxSizerIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<StaticBoxSizerIsOwned<OWNED>> for SizerIsOwned<OWNED> {
+    fn from(o: StaticBoxSizerIsOwned<OWNED>) -> Self {
+        unsafe { SizerIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<StaticBoxSizerIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
+    fn from(o: StaticBoxSizerIsOwned<OWNED>) -> Self {
+        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for StaticBoxSizerIsOwned<OWNED> {
@@ -2415,6 +3197,26 @@ impl<const OWNED: bool> StaticTextIsOwned<OWNED> {
     }
     pub fn none() -> Option<&'static Self> {
         None
+    }
+}
+impl<const OWNED: bool> From<StaticTextIsOwned<OWNED>> for ControlIsOwned<OWNED> {
+    fn from(o: StaticTextIsOwned<OWNED>) -> Self {
+        unsafe { ControlIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<StaticTextIsOwned<OWNED>> for WindowIsOwned<OWNED> {
+    fn from(o: StaticTextIsOwned<OWNED>) -> Self {
+        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<StaticTextIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
+    fn from(o: StaticTextIsOwned<OWNED>) -> Self {
+        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<StaticTextIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
+    fn from(o: StaticTextIsOwned<OWNED>) -> Self {
+        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for StaticTextIsOwned<OWNED> {
@@ -2495,6 +3297,26 @@ impl<const OWNED: bool> TextCtrlIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> From<TextCtrlIsOwned<OWNED>> for ControlIsOwned<OWNED> {
+    fn from(o: TextCtrlIsOwned<OWNED>) -> Self {
+        unsafe { ControlIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<TextCtrlIsOwned<OWNED>> for WindowIsOwned<OWNED> {
+    fn from(o: TextCtrlIsOwned<OWNED>) -> Self {
+        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<TextCtrlIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
+    fn from(o: TextCtrlIsOwned<OWNED>) -> Self {
+        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<TextCtrlIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
+    fn from(o: TextCtrlIsOwned<OWNED>) -> Self {
+        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
 impl<const OWNED: bool> DynamicCast for TextCtrlIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxTextCtrl_CLASSINFO()) }
@@ -2546,6 +3368,26 @@ impl<const OWNED: bool> ToolBarIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> From<ToolBarIsOwned<OWNED>> for ControlIsOwned<OWNED> {
+    fn from(o: ToolBarIsOwned<OWNED>) -> Self {
+        unsafe { ControlIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<ToolBarIsOwned<OWNED>> for WindowIsOwned<OWNED> {
+    fn from(o: ToolBarIsOwned<OWNED>) -> Self {
+        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<ToolBarIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
+    fn from(o: ToolBarIsOwned<OWNED>) -> Self {
+        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<ToolBarIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
+    fn from(o: ToolBarIsOwned<OWNED>) -> Self {
+        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
 impl<const OWNED: bool> DynamicCast for ToolBarIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxToolBar_CLASSINFO()) }
@@ -2594,6 +3436,26 @@ impl<const OWNED: bool> TopLevelWindowIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> From<TopLevelWindowIsOwned<OWNED>> for NonOwnedWindowIsOwned<OWNED> {
+    fn from(o: TopLevelWindowIsOwned<OWNED>) -> Self {
+        unsafe { NonOwnedWindowIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<TopLevelWindowIsOwned<OWNED>> for WindowIsOwned<OWNED> {
+    fn from(o: TopLevelWindowIsOwned<OWNED>) -> Self {
+        unsafe { WindowIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<TopLevelWindowIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
+    fn from(o: TopLevelWindowIsOwned<OWNED>) -> Self {
+        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<TopLevelWindowIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
+    fn from(o: TopLevelWindowIsOwned<OWNED>) -> Self {
+        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
 impl<const OWNED: bool> DynamicCast for TopLevelWindowIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxTopLevelWindow_CLASSINFO()) }
@@ -2613,6 +3475,16 @@ impl<const OWNED: bool> ValidatorIsOwned<OWNED> {
     }
     pub fn none() -> Option<&'static Self> {
         None
+    }
+}
+impl<const OWNED: bool> From<ValidatorIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
+    fn from(o: ValidatorIsOwned<OWNED>) -> Self {
+        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<ValidatorIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
+    fn from(o: ValidatorIsOwned<OWNED>) -> Self {
+        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for ValidatorIsOwned<OWNED> {
@@ -2656,6 +3528,16 @@ impl<const OWNED: bool> WindowIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> From<WindowIsOwned<OWNED>> for EvtHandlerIsOwned<OWNED> {
+    fn from(o: WindowIsOwned<OWNED>) -> Self {
+        unsafe { EvtHandlerIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<WindowIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
+    fn from(o: WindowIsOwned<OWNED>) -> Self {
+        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
 impl<const OWNED: bool> DynamicCast for WindowIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxWindow_CLASSINFO()) }
@@ -2676,6 +3558,21 @@ impl<const OWNED: bool> WrapSizerIsOwned<OWNED> {
     }
     pub fn none() -> Option<&'static Self> {
         None
+    }
+}
+impl<const OWNED: bool> From<WrapSizerIsOwned<OWNED>> for BoxSizerIsOwned<OWNED> {
+    fn from(o: WrapSizerIsOwned<OWNED>) -> Self {
+        unsafe { BoxSizerIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<WrapSizerIsOwned<OWNED>> for SizerIsOwned<OWNED> {
+    fn from(o: WrapSizerIsOwned<OWNED>) -> Self {
+        unsafe { SizerIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> From<WrapSizerIsOwned<OWNED>> for ObjectIsOwned<OWNED> {
+    fn from(o: WrapSizerIsOwned<OWNED>) -> Self {
+        unsafe { ObjectIsOwned::from_ptr(o.as_ptr()) }
     }
 }
 impl<const OWNED: bool> DynamicCast for WrapSizerIsOwned<OWNED> {

--- a/wx-core/src/generated.rs
+++ b/wx-core/src/generated.rs
@@ -488,21 +488,6 @@ impl<const OWNED: bool> ListBoxMethods for CheckListBoxIsOwned<OWNED> {
         }
     }
 }
-impl<const OWNED: bool> From<CheckListBoxIsOwned<OWNED>> for ListBoxIsOwned<OWNED> {
-    fn from(o: CheckListBoxIsOwned<OWNED>) -> Self {
-        unsafe { ListBoxIsOwned::from_ptr(o.as_ptr()) }
-    }
-}
-impl<const OWNED: bool> TryFrom<&ListBoxIsOwned<OWNED>> for CheckListBoxIsOwned<false> {
-    type Error = ();
-    fn try_from(lbox: &ListBoxIsOwned<OWNED>) -> Result<Self, Self::Error> {
-        if lbox.is_kind_of(Some(&CheckListBox::class_info())) {
-            unsafe { Ok(CheckListBox::from_unowned_ptr(lbox.as_ptr())) }
-        } else {
-            Err(())
-        }
-    }
-}
 
 // wxChoice
 wx_class! { Choice =

--- a/wx-core/src/generated.rs
+++ b/wx-core/src/generated.rs
@@ -32,6 +32,11 @@ impl<const OWNED: bool> AnyButtonIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> ClassInfoMacro for AnyButtonIsOwned<OWNED> {
+    fn class_info() -> ClassInfoIsOwned<false> {
+        unsafe { ClassInfoIsOwned::from_ptr(ffi::wxAnyButton_CLASSINFO()) }
+    }
+}
 
 // wxArtProvider
 wx_class! { ArtProvider =
@@ -42,6 +47,11 @@ wx_class! { ArtProvider =
 impl<const OWNED: bool> ArtProviderIsOwned<OWNED> {
     pub fn none() -> Option<&'static Self> {
         None
+    }
+}
+impl<const OWNED: bool> ClassInfoMacro for ArtProviderIsOwned<OWNED> {
+    fn class_info() -> ClassInfoIsOwned<false> {
+        unsafe { ClassInfoIsOwned::from_ptr(ffi::wxArtProvider_CLASSINFO()) }
     }
 }
 impl<const OWNED: bool> Drop for ArtProviderIsOwned<OWNED> {
@@ -97,6 +107,11 @@ impl<const OWNED: bool> BitmapIsOwned<OWNED> {
     }
     pub fn none() -> Option<&'static Self> {
         None
+    }
+}
+impl<const OWNED: bool> ClassInfoMacro for BitmapIsOwned<OWNED> {
+    fn class_info() -> ClassInfoIsOwned<false> {
+        unsafe { ClassInfoIsOwned::from_ptr(ffi::wxBitmap_CLASSINFO()) }
     }
 }
 impl<const OWNED: bool> Drop for BitmapIsOwned<OWNED> {
@@ -203,6 +218,11 @@ impl<const OWNED: bool> BitmapButtonIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> ClassInfoMacro for BitmapButtonIsOwned<OWNED> {
+    fn class_info() -> ClassInfoIsOwned<false> {
+        unsafe { ClassInfoIsOwned::from_ptr(ffi::wxBitmapButton_CLASSINFO()) }
+    }
+}
 
 // wxBookCtrlBase
 wx_class! { BookCtrlBase =
@@ -221,6 +241,11 @@ impl<const OWNED: bool> BookCtrlBaseIsOwned<OWNED> {
     // BLOCKED: fn wxBookCtrlBase1()
     pub fn none() -> Option<&'static Self> {
         None
+    }
+}
+impl<const OWNED: bool> ClassInfoMacro for BookCtrlBaseIsOwned<OWNED> {
+    fn class_info() -> ClassInfoIsOwned<false> {
+        unsafe { ClassInfoIsOwned::from_ptr(ffi::wxBookCtrlBase_CLASSINFO()) }
     }
 }
 impl<const OWNED: bool> WindowMethods for BookCtrlBaseIsOwned<OWNED> {
@@ -262,6 +287,11 @@ impl<const OWNED: bool> BookCtrlEventIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> ClassInfoMacro for BookCtrlEventIsOwned<OWNED> {
+    fn class_info() -> ClassInfoIsOwned<false> {
+        unsafe { ClassInfoIsOwned::from_ptr(ffi::wxBookCtrlEvent_CLASSINFO()) }
+    }
+}
 impl<const OWNED: bool> Drop for BookCtrlEventIsOwned<OWNED> {
     fn drop(&mut self) {
         if OWNED {
@@ -288,6 +318,11 @@ impl<const OWNED: bool> BoxSizerIsOwned<OWNED> {
     }
     pub fn none() -> Option<&'static Self> {
         None
+    }
+}
+impl<const OWNED: bool> ClassInfoMacro for BoxSizerIsOwned<OWNED> {
+    fn class_info() -> ClassInfoIsOwned<false> {
+        unsafe { ClassInfoIsOwned::from_ptr(ffi::wxBoxSizer_CLASSINFO()) }
     }
 }
 
@@ -336,6 +371,11 @@ impl<const OWNED: bool> ButtonIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> ClassInfoMacro for ButtonIsOwned<OWNED> {
+    fn class_info() -> ClassInfoIsOwned<false> {
+        unsafe { ClassInfoIsOwned::from_ptr(ffi::wxButton_CLASSINFO()) }
+    }
+}
 
 // wxCheckBox
 wx_class! { CheckBox =
@@ -379,6 +419,11 @@ impl<const OWNED: bool> CheckBoxIsOwned<OWNED> {
     }
     pub fn none() -> Option<&'static Self> {
         None
+    }
+}
+impl<const OWNED: bool> ClassInfoMacro for CheckBoxIsOwned<OWNED> {
+    fn class_info() -> ClassInfoIsOwned<false> {
+        unsafe { ClassInfoIsOwned::from_ptr(ffi::wxCheckBox_CLASSINFO()) }
     }
 }
 
@@ -431,6 +476,11 @@ impl<const OWNED: bool> CheckListBoxIsOwned<OWNED> {
     }
     pub fn none() -> Option<&'static Self> {
         None
+    }
+}
+impl<const OWNED: bool> ClassInfoMacro for CheckListBoxIsOwned<OWNED> {
+    fn class_info() -> ClassInfoIsOwned<false> {
+        unsafe { ClassInfoIsOwned::from_ptr(ffi::wxCheckListBox_CLASSINFO()) }
     }
 }
 // Mix-in(s) to wxCheckListBox
@@ -539,6 +589,11 @@ impl<const OWNED: bool> ChoiceIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> ClassInfoMacro for ChoiceIsOwned<OWNED> {
+    fn class_info() -> ClassInfoIsOwned<false> {
+        unsafe { ClassInfoIsOwned::from_ptr(ffi::wxChoice_CLASSINFO()) }
+    }
+}
 // Mix-in(s) to wxChoice
 impl<const OWNED: bool> ItemContainerMethods for ChoiceIsOwned<OWNED> {
     fn as_item_container(&self) -> *mut c_void {
@@ -578,6 +633,11 @@ impl<const OWNED: bool> ColourIsOwned<OWNED> {
     }
     pub fn none() -> Option<&'static Self> {
         None
+    }
+}
+impl<const OWNED: bool> ClassInfoMacro for ColourIsOwned<OWNED> {
+    fn class_info() -> ClassInfoIsOwned<false> {
+        unsafe { ClassInfoIsOwned::from_ptr(ffi::wxColour_CLASSINFO()) }
     }
 }
 impl<const OWNED: bool> Drop for ColourIsOwned<OWNED> {
@@ -638,6 +698,11 @@ impl<const OWNED: bool> ColourPickerCtrlIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> ClassInfoMacro for ColourPickerCtrlIsOwned<OWNED> {
+    fn class_info() -> ClassInfoIsOwned<false> {
+        unsafe { ClassInfoIsOwned::from_ptr(ffi::wxColourPickerCtrl_CLASSINFO()) }
+    }
+}
 
 // wxComboBox
 wx_class! { ComboBox =
@@ -692,6 +757,11 @@ impl<const OWNED: bool> ComboBoxIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> ClassInfoMacro for ComboBoxIsOwned<OWNED> {
+    fn class_info() -> ClassInfoIsOwned<false> {
+        unsafe { ClassInfoIsOwned::from_ptr(ffi::wxComboBox_CLASSINFO()) }
+    }
+}
 // Mix-in(s) to wxComboBox
 impl<const OWNED: bool> ItemContainerMethods for ComboBoxIsOwned<OWNED> {
     fn as_item_container(&self) -> *mut c_void {
@@ -720,6 +790,11 @@ impl<const OWNED: bool> CommandEventIsOwned<OWNED> {
     // NOT_SUPPORTED: fn wxCommandEvent()
     pub fn none() -> Option<&'static Self> {
         None
+    }
+}
+impl<const OWNED: bool> ClassInfoMacro for CommandEventIsOwned<OWNED> {
+    fn class_info() -> ClassInfoIsOwned<false> {
+        unsafe { ClassInfoIsOwned::from_ptr(ffi::wxCommandEvent_CLASSINFO()) }
     }
 }
 impl<const OWNED: bool> Drop for CommandEventIsOwned<OWNED> {
@@ -768,6 +843,11 @@ impl<const OWNED: bool> ControlIsOwned<OWNED> {
     }
     pub fn none() -> Option<&'static Self> {
         None
+    }
+}
+impl<const OWNED: bool> ClassInfoMacro for ControlIsOwned<OWNED> {
+    fn class_info() -> ClassInfoIsOwned<false> {
+        unsafe { ClassInfoIsOwned::from_ptr(ffi::wxControl_CLASSINFO()) }
     }
 }
 
@@ -820,6 +900,11 @@ impl<const OWNED: bool> DatePickerCtrlIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> ClassInfoMacro for DatePickerCtrlIsOwned<OWNED> {
+    fn class_info() -> ClassInfoIsOwned<false> {
+        unsafe { ClassInfoIsOwned::from_ptr(ffi::wxDatePickerCtrl_CLASSINFO()) }
+    }
+}
 
 // wxDirPickerCtrl
 wx_class! { DirPickerCtrl =
@@ -869,6 +954,11 @@ impl<const OWNED: bool> DirPickerCtrlIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> ClassInfoMacro for DirPickerCtrlIsOwned<OWNED> {
+    fn class_info() -> ClassInfoIsOwned<false> {
+        unsafe { ClassInfoIsOwned::from_ptr(ffi::wxDirPickerCtrl_CLASSINFO()) }
+    }
+}
 
 // wxEditableListBox
 wx_class! { EditableListBox =
@@ -910,6 +1000,11 @@ impl<const OWNED: bool> EditableListBoxIsOwned<OWNED> {
     }
     pub fn none() -> Option<&'static Self> {
         None
+    }
+}
+impl<const OWNED: bool> ClassInfoMacro for EditableListBoxIsOwned<OWNED> {
+    fn class_info() -> ClassInfoIsOwned<false> {
+        unsafe { ClassInfoIsOwned::from_ptr(ffi::wxEditableListBox_CLASSINFO()) }
     }
 }
 
@@ -969,6 +1064,11 @@ impl<const OWNED: bool> FileCtrlIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> ClassInfoMacro for FileCtrlIsOwned<OWNED> {
+    fn class_info() -> ClassInfoIsOwned<false> {
+        unsafe { ClassInfoIsOwned::from_ptr(ffi::wxFileCtrl_CLASSINFO()) }
+    }
+}
 
 // wxFont
 wx_class! { Font =
@@ -1004,6 +1104,11 @@ impl<const OWNED: bool> FontIsOwned<OWNED> {
     }
     pub fn none() -> Option<&'static Self> {
         None
+    }
+}
+impl<const OWNED: bool> ClassInfoMacro for FontIsOwned<OWNED> {
+    fn class_info() -> ClassInfoIsOwned<false> {
+        unsafe { ClassInfoIsOwned::from_ptr(ffi::wxFont_CLASSINFO()) }
     }
 }
 impl<const OWNED: bool> Drop for FontIsOwned<OWNED> {
@@ -1064,6 +1169,11 @@ impl<const OWNED: bool> FontPickerCtrlIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> ClassInfoMacro for FontPickerCtrlIsOwned<OWNED> {
+    fn class_info() -> ClassInfoIsOwned<false> {
+        unsafe { ClassInfoIsOwned::from_ptr(ffi::wxFontPickerCtrl_CLASSINFO()) }
+    }
+}
 
 // wxFrame
 wx_class! { Frame =
@@ -1104,6 +1214,11 @@ impl<const OWNED: bool> FrameIsOwned<OWNED> {
     }
     pub fn none() -> Option<&'static Self> {
         None
+    }
+}
+impl<const OWNED: bool> ClassInfoMacro for FrameIsOwned<OWNED> {
+    fn class_info() -> ClassInfoIsOwned<false> {
+        unsafe { ClassInfoIsOwned::from_ptr(ffi::wxFrame_CLASSINFO()) }
     }
 }
 impl<const OWNED: bool> TopLevelWindowMethods for FrameIsOwned<OWNED> {
@@ -1148,6 +1263,11 @@ impl<const OWNED: bool> GDIObjectIsOwned<OWNED> {
     // BLOCKED: fn wxGDIObject()
     pub fn none() -> Option<&'static Self> {
         None
+    }
+}
+impl<const OWNED: bool> ClassInfoMacro for GDIObjectIsOwned<OWNED> {
+    fn class_info() -> ClassInfoIsOwned<false> {
+        unsafe { ClassInfoIsOwned::from_ptr(ffi::wxGDIObject_CLASSINFO()) }
     }
 }
 impl<const OWNED: bool> Drop for GDIObjectIsOwned<OWNED> {
@@ -1198,6 +1318,11 @@ impl<const OWNED: bool> GaugeIsOwned<OWNED> {
     }
     pub fn none() -> Option<&'static Self> {
         None
+    }
+}
+impl<const OWNED: bool> ClassInfoMacro for GaugeIsOwned<OWNED> {
+    fn class_info() -> ClassInfoIsOwned<false> {
+        unsafe { ClassInfoIsOwned::from_ptr(ffi::wxGauge_CLASSINFO()) }
     }
 }
 
@@ -1253,6 +1378,11 @@ impl<const OWNED: bool> GenericDirCtrlIsOwned<OWNED> {
     }
     pub fn none() -> Option<&'static Self> {
         None
+    }
+}
+impl<const OWNED: bool> ClassInfoMacro for GenericDirCtrlIsOwned<OWNED> {
+    fn class_info() -> ClassInfoIsOwned<false> {
+        unsafe { ClassInfoIsOwned::from_ptr(ffi::wxGenericDirCtrl_CLASSINFO()) }
     }
 }
 
@@ -1333,6 +1463,11 @@ impl<const OWNED: bool> HeaderCtrlIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> ClassInfoMacro for HeaderCtrlIsOwned<OWNED> {
+    fn class_info() -> ClassInfoIsOwned<false> {
+        unsafe { ClassInfoIsOwned::from_ptr(ffi::wxHeaderCtrl_CLASSINFO()) }
+    }
+}
 impl<const OWNED: bool> WindowMethods for HeaderCtrlIsOwned<OWNED> {
     fn create<W: WindowMethods, P: PointMethods, S: SizeMethods>(
         &self,
@@ -1397,6 +1532,11 @@ impl<const OWNED: bool> HeaderCtrlSimpleIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> ClassInfoMacro for HeaderCtrlSimpleIsOwned<OWNED> {
+    fn class_info() -> ClassInfoIsOwned<false> {
+        unsafe { ClassInfoIsOwned::from_ptr(ffi::wxHeaderCtrlSimple_CLASSINFO()) }
+    }
+}
 
 // wxHyperlinkCtrl
 wx_class! { HyperlinkCtrl =
@@ -1443,6 +1583,11 @@ impl<const OWNED: bool> HyperlinkCtrlIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> ClassInfoMacro for HyperlinkCtrlIsOwned<OWNED> {
+    fn class_info() -> ClassInfoIsOwned<false> {
+        unsafe { ClassInfoIsOwned::from_ptr(ffi::wxHyperlinkCtrl_CLASSINFO()) }
+    }
+}
 
 // wxIcon
 wx_class! { Icon =
@@ -1471,6 +1616,11 @@ impl<const OWNED: bool> IconIsOwned<OWNED> {
     }
     pub fn none() -> Option<&'static Self> {
         None
+    }
+}
+impl<const OWNED: bool> ClassInfoMacro for IconIsOwned<OWNED> {
+    fn class_info() -> ClassInfoIsOwned<false> {
+        unsafe { ClassInfoIsOwned::from_ptr(ffi::wxIcon_CLASSINFO()) }
     }
 }
 impl<const OWNED: bool> Drop for IconIsOwned<OWNED> {
@@ -1535,6 +1685,11 @@ impl<const OWNED: bool> ListBoxIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> ClassInfoMacro for ListBoxIsOwned<OWNED> {
+    fn class_info() -> ClassInfoIsOwned<false> {
+        unsafe { ClassInfoIsOwned::from_ptr(ffi::wxListBox_CLASSINFO()) }
+    }
+}
 // Mix-in(s) to wxListBox
 impl<const OWNED: bool> ItemContainerMethods for ListBoxIsOwned<OWNED> {
     fn as_item_container(&self) -> *mut c_void {
@@ -1572,6 +1727,11 @@ impl<const OWNED: bool> MenuIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> ClassInfoMacro for MenuIsOwned<OWNED> {
+    fn class_info() -> ClassInfoIsOwned<false> {
+        unsafe { ClassInfoIsOwned::from_ptr(ffi::wxMenu_CLASSINFO()) }
+    }
+}
 
 // wxMenuBar
 wx_class! { MenuBar =
@@ -1588,6 +1748,11 @@ impl<const OWNED: bool> MenuBarIsOwned<OWNED> {
     // NOT_SUPPORTED: fn wxMenuBar1()
     pub fn none() -> Option<&'static Self> {
         None
+    }
+}
+impl<const OWNED: bool> ClassInfoMacro for MenuBarIsOwned<OWNED> {
+    fn class_info() -> ClassInfoIsOwned<false> {
+        unsafe { ClassInfoIsOwned::from_ptr(ffi::wxMenuBar_CLASSINFO()) }
     }
 }
 
@@ -1633,6 +1798,11 @@ impl<const OWNED: bool> MenuItemIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> ClassInfoMacro for MenuItemIsOwned<OWNED> {
+    fn class_info() -> ClassInfoIsOwned<false> {
+        unsafe { ClassInfoIsOwned::from_ptr(ffi::wxMenuItem_CLASSINFO()) }
+    }
+}
 impl<const OWNED: bool> Drop for MenuItemIsOwned<OWNED> {
     fn drop(&mut self) {
         if OWNED {
@@ -1652,6 +1822,11 @@ wx_class! { NonOwnedWindow =
 impl<const OWNED: bool> NonOwnedWindowIsOwned<OWNED> {
     pub fn none() -> Option<&'static Self> {
         None
+    }
+}
+impl<const OWNED: bool> ClassInfoMacro for NonOwnedWindowIsOwned<OWNED> {
+    fn class_info() -> ClassInfoIsOwned<false> {
+        unsafe { ClassInfoIsOwned::from_ptr(ffi::wxNonOwnedWindow_CLASSINFO()) }
     }
 }
 
@@ -1693,6 +1868,11 @@ impl<const OWNED: bool> NotebookIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> ClassInfoMacro for NotebookIsOwned<OWNED> {
+    fn class_info() -> ClassInfoIsOwned<false> {
+        unsafe { ClassInfoIsOwned::from_ptr(ffi::wxNotebook_CLASSINFO()) }
+    }
+}
 impl<const OWNED: bool> BookCtrlBaseMethods for NotebookIsOwned<OWNED> {
     // BLOCKED: fn Create()
 }
@@ -1712,6 +1892,11 @@ impl<const OWNED: bool> NotifyEventIsOwned<OWNED> {
     // NOT_SUPPORTED: fn wxNotifyEvent()
     pub fn none() -> Option<&'static Self> {
         None
+    }
+}
+impl<const OWNED: bool> ClassInfoMacro for NotifyEventIsOwned<OWNED> {
+    fn class_info() -> ClassInfoIsOwned<false> {
+        unsafe { ClassInfoIsOwned::from_ptr(ffi::wxNotifyEvent_CLASSINFO()) }
     }
 }
 impl<const OWNED: bool> Drop for NotifyEventIsOwned<OWNED> {
@@ -1758,6 +1943,11 @@ impl<const OWNED: bool> PanelIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> ClassInfoMacro for PanelIsOwned<OWNED> {
+    fn class_info() -> ClassInfoIsOwned<false> {
+        unsafe { ClassInfoIsOwned::from_ptr(ffi::wxPanel_CLASSINFO()) }
+    }
+}
 impl<const OWNED: bool> WindowMethods for PanelIsOwned<OWNED> {
     fn create<W: WindowMethods, P: PointMethods, S: SizeMethods>(
         &self,
@@ -1795,6 +1985,11 @@ impl<const OWNED: bool> PickerBaseIsOwned<OWNED> {
     // BLOCKED: fn wxPickerBase()
     pub fn none() -> Option<&'static Self> {
         None
+    }
+}
+impl<const OWNED: bool> ClassInfoMacro for PickerBaseIsOwned<OWNED> {
+    fn class_info() -> ClassInfoIsOwned<false> {
+        unsafe { ClassInfoIsOwned::from_ptr(ffi::wxPickerBase_CLASSINFO()) }
     }
 }
 
@@ -1886,6 +2081,11 @@ impl<const OWNED: bool> RadioBoxIsOwned<OWNED> {
     }
     pub fn none() -> Option<&'static Self> {
         None
+    }
+}
+impl<const OWNED: bool> ClassInfoMacro for RadioBoxIsOwned<OWNED> {
+    fn class_info() -> ClassInfoIsOwned<false> {
+        unsafe { ClassInfoIsOwned::from_ptr(ffi::wxRadioBox_CLASSINFO()) }
     }
 }
 // Mix-in(s) to wxRadioBox
@@ -2000,6 +2200,11 @@ impl<const OWNED: bool> SizerIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> ClassInfoMacro for SizerIsOwned<OWNED> {
+    fn class_info() -> ClassInfoIsOwned<false> {
+        unsafe { ClassInfoIsOwned::from_ptr(ffi::wxSizer_CLASSINFO()) }
+    }
+}
 
 // wxSizerFlags
 wx_class! { SizerFlags =
@@ -2069,6 +2274,11 @@ impl<const OWNED: bool> StaticBitmapIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> ClassInfoMacro for StaticBitmapIsOwned<OWNED> {
+    fn class_info() -> ClassInfoIsOwned<false> {
+        unsafe { ClassInfoIsOwned::from_ptr(ffi::wxStaticBitmap_CLASSINFO()) }
+    }
+}
 
 // wxStaticBox
 wx_class! { StaticBox =
@@ -2113,6 +2323,11 @@ impl<const OWNED: bool> StaticBoxIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> ClassInfoMacro for StaticBoxIsOwned<OWNED> {
+    fn class_info() -> ClassInfoIsOwned<false> {
+        unsafe { ClassInfoIsOwned::from_ptr(ffi::wxStaticBox_CLASSINFO()) }
+    }
+}
 
 // wxStaticBoxSizer
 wx_class! { StaticBoxSizer =
@@ -2152,6 +2367,11 @@ impl<const OWNED: bool> StaticBoxSizerIsOwned<OWNED> {
     }
     pub fn none() -> Option<&'static Self> {
         None
+    }
+}
+impl<const OWNED: bool> ClassInfoMacro for StaticBoxSizerIsOwned<OWNED> {
+    fn class_info() -> ClassInfoIsOwned<false> {
+        unsafe { ClassInfoIsOwned::from_ptr(ffi::wxStaticBoxSizer_CLASSINFO()) }
     }
 }
 
@@ -2195,6 +2415,11 @@ impl<const OWNED: bool> StaticTextIsOwned<OWNED> {
     }
     pub fn none() -> Option<&'static Self> {
         None
+    }
+}
+impl<const OWNED: bool> ClassInfoMacro for StaticTextIsOwned<OWNED> {
+    fn class_info() -> ClassInfoIsOwned<false> {
+        unsafe { ClassInfoIsOwned::from_ptr(ffi::wxStaticText_CLASSINFO()) }
     }
 }
 
@@ -2270,6 +2495,11 @@ impl<const OWNED: bool> TextCtrlIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> ClassInfoMacro for TextCtrlIsOwned<OWNED> {
+    fn class_info() -> ClassInfoIsOwned<false> {
+        unsafe { ClassInfoIsOwned::from_ptr(ffi::wxTextCtrl_CLASSINFO()) }
+    }
+}
 // Mix-in(s) to wxTextCtrl
 impl<const OWNED: bool> TextEntryMethods for TextCtrlIsOwned<OWNED> {
     fn as_text_entry(&self) -> *mut c_void {
@@ -2316,6 +2546,11 @@ impl<const OWNED: bool> ToolBarIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> ClassInfoMacro for ToolBarIsOwned<OWNED> {
+    fn class_info() -> ClassInfoIsOwned<false> {
+        unsafe { ClassInfoIsOwned::from_ptr(ffi::wxToolBar_CLASSINFO()) }
+    }
+}
 
 // wxTopLevelWindow
 wx_class! { TopLevelWindow =
@@ -2359,6 +2594,11 @@ impl<const OWNED: bool> TopLevelWindowIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> ClassInfoMacro for TopLevelWindowIsOwned<OWNED> {
+    fn class_info() -> ClassInfoIsOwned<false> {
+        unsafe { ClassInfoIsOwned::from_ptr(ffi::wxTopLevelWindow_CLASSINFO()) }
+    }
+}
 
 // wxValidator
 wx_class! { Validator =
@@ -2373,6 +2613,11 @@ impl<const OWNED: bool> ValidatorIsOwned<OWNED> {
     }
     pub fn none() -> Option<&'static Self> {
         None
+    }
+}
+impl<const OWNED: bool> ClassInfoMacro for ValidatorIsOwned<OWNED> {
+    fn class_info() -> ClassInfoIsOwned<false> {
+        unsafe { ClassInfoIsOwned::from_ptr(ffi::wxValidator_CLASSINFO()) }
     }
 }
 
@@ -2411,6 +2656,11 @@ impl<const OWNED: bool> WindowIsOwned<OWNED> {
         None
     }
 }
+impl<const OWNED: bool> ClassInfoMacro for WindowIsOwned<OWNED> {
+    fn class_info() -> ClassInfoIsOwned<false> {
+        unsafe { ClassInfoIsOwned::from_ptr(ffi::wxWindow_CLASSINFO()) }
+    }
+}
 
 // wxWrapSizer
 wx_class! { WrapSizer =
@@ -2426,5 +2676,10 @@ impl<const OWNED: bool> WrapSizerIsOwned<OWNED> {
     }
     pub fn none() -> Option<&'static Self> {
         None
+    }
+}
+impl<const OWNED: bool> ClassInfoMacro for WrapSizerIsOwned<OWNED> {
+    fn class_info() -> ClassInfoIsOwned<false> {
+        unsafe { ClassInfoIsOwned::from_ptr(ffi::wxWrapSizer_CLASSINFO()) }
     }
 }

--- a/wx-core/src/generated.rs
+++ b/wx-core/src/generated.rs
@@ -32,7 +32,7 @@ impl<const OWNED: bool> AnyButtonIsOwned<OWNED> {
         None
     }
 }
-impl<const OWNED: bool> ClassInfoMacro for AnyButtonIsOwned<OWNED> {
+impl<const OWNED: bool> DynamicCast for AnyButtonIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxAnyButton_CLASSINFO()) }
     }
@@ -49,7 +49,7 @@ impl<const OWNED: bool> ArtProviderIsOwned<OWNED> {
         None
     }
 }
-impl<const OWNED: bool> ClassInfoMacro for ArtProviderIsOwned<OWNED> {
+impl<const OWNED: bool> DynamicCast for ArtProviderIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxArtProvider_CLASSINFO()) }
     }
@@ -109,7 +109,7 @@ impl<const OWNED: bool> BitmapIsOwned<OWNED> {
         None
     }
 }
-impl<const OWNED: bool> ClassInfoMacro for BitmapIsOwned<OWNED> {
+impl<const OWNED: bool> DynamicCast for BitmapIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxBitmap_CLASSINFO()) }
     }
@@ -218,7 +218,7 @@ impl<const OWNED: bool> BitmapButtonIsOwned<OWNED> {
         None
     }
 }
-impl<const OWNED: bool> ClassInfoMacro for BitmapButtonIsOwned<OWNED> {
+impl<const OWNED: bool> DynamicCast for BitmapButtonIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxBitmapButton_CLASSINFO()) }
     }
@@ -243,7 +243,7 @@ impl<const OWNED: bool> BookCtrlBaseIsOwned<OWNED> {
         None
     }
 }
-impl<const OWNED: bool> ClassInfoMacro for BookCtrlBaseIsOwned<OWNED> {
+impl<const OWNED: bool> DynamicCast for BookCtrlBaseIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxBookCtrlBase_CLASSINFO()) }
     }
@@ -287,7 +287,7 @@ impl<const OWNED: bool> BookCtrlEventIsOwned<OWNED> {
         None
     }
 }
-impl<const OWNED: bool> ClassInfoMacro for BookCtrlEventIsOwned<OWNED> {
+impl<const OWNED: bool> DynamicCast for BookCtrlEventIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxBookCtrlEvent_CLASSINFO()) }
     }
@@ -320,7 +320,7 @@ impl<const OWNED: bool> BoxSizerIsOwned<OWNED> {
         None
     }
 }
-impl<const OWNED: bool> ClassInfoMacro for BoxSizerIsOwned<OWNED> {
+impl<const OWNED: bool> DynamicCast for BoxSizerIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxBoxSizer_CLASSINFO()) }
     }
@@ -371,7 +371,7 @@ impl<const OWNED: bool> ButtonIsOwned<OWNED> {
         None
     }
 }
-impl<const OWNED: bool> ClassInfoMacro for ButtonIsOwned<OWNED> {
+impl<const OWNED: bool> DynamicCast for ButtonIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxButton_CLASSINFO()) }
     }
@@ -421,7 +421,7 @@ impl<const OWNED: bool> CheckBoxIsOwned<OWNED> {
         None
     }
 }
-impl<const OWNED: bool> ClassInfoMacro for CheckBoxIsOwned<OWNED> {
+impl<const OWNED: bool> DynamicCast for CheckBoxIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxCheckBox_CLASSINFO()) }
     }
@@ -478,7 +478,7 @@ impl<const OWNED: bool> CheckListBoxIsOwned<OWNED> {
         None
     }
 }
-impl<const OWNED: bool> ClassInfoMacro for CheckListBoxIsOwned<OWNED> {
+impl<const OWNED: bool> DynamicCast for CheckListBoxIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxCheckListBox_CLASSINFO()) }
     }
@@ -589,7 +589,7 @@ impl<const OWNED: bool> ChoiceIsOwned<OWNED> {
         None
     }
 }
-impl<const OWNED: bool> ClassInfoMacro for ChoiceIsOwned<OWNED> {
+impl<const OWNED: bool> DynamicCast for ChoiceIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxChoice_CLASSINFO()) }
     }
@@ -635,7 +635,7 @@ impl<const OWNED: bool> ColourIsOwned<OWNED> {
         None
     }
 }
-impl<const OWNED: bool> ClassInfoMacro for ColourIsOwned<OWNED> {
+impl<const OWNED: bool> DynamicCast for ColourIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxColour_CLASSINFO()) }
     }
@@ -698,7 +698,7 @@ impl<const OWNED: bool> ColourPickerCtrlIsOwned<OWNED> {
         None
     }
 }
-impl<const OWNED: bool> ClassInfoMacro for ColourPickerCtrlIsOwned<OWNED> {
+impl<const OWNED: bool> DynamicCast for ColourPickerCtrlIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxColourPickerCtrl_CLASSINFO()) }
     }
@@ -757,7 +757,7 @@ impl<const OWNED: bool> ComboBoxIsOwned<OWNED> {
         None
     }
 }
-impl<const OWNED: bool> ClassInfoMacro for ComboBoxIsOwned<OWNED> {
+impl<const OWNED: bool> DynamicCast for ComboBoxIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxComboBox_CLASSINFO()) }
     }
@@ -792,7 +792,7 @@ impl<const OWNED: bool> CommandEventIsOwned<OWNED> {
         None
     }
 }
-impl<const OWNED: bool> ClassInfoMacro for CommandEventIsOwned<OWNED> {
+impl<const OWNED: bool> DynamicCast for CommandEventIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxCommandEvent_CLASSINFO()) }
     }
@@ -845,7 +845,7 @@ impl<const OWNED: bool> ControlIsOwned<OWNED> {
         None
     }
 }
-impl<const OWNED: bool> ClassInfoMacro for ControlIsOwned<OWNED> {
+impl<const OWNED: bool> DynamicCast for ControlIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxControl_CLASSINFO()) }
     }
@@ -900,7 +900,7 @@ impl<const OWNED: bool> DatePickerCtrlIsOwned<OWNED> {
         None
     }
 }
-impl<const OWNED: bool> ClassInfoMacro for DatePickerCtrlIsOwned<OWNED> {
+impl<const OWNED: bool> DynamicCast for DatePickerCtrlIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxDatePickerCtrl_CLASSINFO()) }
     }
@@ -954,7 +954,7 @@ impl<const OWNED: bool> DirPickerCtrlIsOwned<OWNED> {
         None
     }
 }
-impl<const OWNED: bool> ClassInfoMacro for DirPickerCtrlIsOwned<OWNED> {
+impl<const OWNED: bool> DynamicCast for DirPickerCtrlIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxDirPickerCtrl_CLASSINFO()) }
     }
@@ -1002,7 +1002,7 @@ impl<const OWNED: bool> EditableListBoxIsOwned<OWNED> {
         None
     }
 }
-impl<const OWNED: bool> ClassInfoMacro for EditableListBoxIsOwned<OWNED> {
+impl<const OWNED: bool> DynamicCast for EditableListBoxIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxEditableListBox_CLASSINFO()) }
     }
@@ -1064,7 +1064,7 @@ impl<const OWNED: bool> FileCtrlIsOwned<OWNED> {
         None
     }
 }
-impl<const OWNED: bool> ClassInfoMacro for FileCtrlIsOwned<OWNED> {
+impl<const OWNED: bool> DynamicCast for FileCtrlIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxFileCtrl_CLASSINFO()) }
     }
@@ -1106,7 +1106,7 @@ impl<const OWNED: bool> FontIsOwned<OWNED> {
         None
     }
 }
-impl<const OWNED: bool> ClassInfoMacro for FontIsOwned<OWNED> {
+impl<const OWNED: bool> DynamicCast for FontIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxFont_CLASSINFO()) }
     }
@@ -1169,7 +1169,7 @@ impl<const OWNED: bool> FontPickerCtrlIsOwned<OWNED> {
         None
     }
 }
-impl<const OWNED: bool> ClassInfoMacro for FontPickerCtrlIsOwned<OWNED> {
+impl<const OWNED: bool> DynamicCast for FontPickerCtrlIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxFontPickerCtrl_CLASSINFO()) }
     }
@@ -1216,7 +1216,7 @@ impl<const OWNED: bool> FrameIsOwned<OWNED> {
         None
     }
 }
-impl<const OWNED: bool> ClassInfoMacro for FrameIsOwned<OWNED> {
+impl<const OWNED: bool> DynamicCast for FrameIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxFrame_CLASSINFO()) }
     }
@@ -1265,7 +1265,7 @@ impl<const OWNED: bool> GDIObjectIsOwned<OWNED> {
         None
     }
 }
-impl<const OWNED: bool> ClassInfoMacro for GDIObjectIsOwned<OWNED> {
+impl<const OWNED: bool> DynamicCast for GDIObjectIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxGDIObject_CLASSINFO()) }
     }
@@ -1320,7 +1320,7 @@ impl<const OWNED: bool> GaugeIsOwned<OWNED> {
         None
     }
 }
-impl<const OWNED: bool> ClassInfoMacro for GaugeIsOwned<OWNED> {
+impl<const OWNED: bool> DynamicCast for GaugeIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxGauge_CLASSINFO()) }
     }
@@ -1380,7 +1380,7 @@ impl<const OWNED: bool> GenericDirCtrlIsOwned<OWNED> {
         None
     }
 }
-impl<const OWNED: bool> ClassInfoMacro for GenericDirCtrlIsOwned<OWNED> {
+impl<const OWNED: bool> DynamicCast for GenericDirCtrlIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxGenericDirCtrl_CLASSINFO()) }
     }
@@ -1463,7 +1463,7 @@ impl<const OWNED: bool> HeaderCtrlIsOwned<OWNED> {
         None
     }
 }
-impl<const OWNED: bool> ClassInfoMacro for HeaderCtrlIsOwned<OWNED> {
+impl<const OWNED: bool> DynamicCast for HeaderCtrlIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxHeaderCtrl_CLASSINFO()) }
     }
@@ -1532,7 +1532,7 @@ impl<const OWNED: bool> HeaderCtrlSimpleIsOwned<OWNED> {
         None
     }
 }
-impl<const OWNED: bool> ClassInfoMacro for HeaderCtrlSimpleIsOwned<OWNED> {
+impl<const OWNED: bool> DynamicCast for HeaderCtrlSimpleIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxHeaderCtrlSimple_CLASSINFO()) }
     }
@@ -1583,7 +1583,7 @@ impl<const OWNED: bool> HyperlinkCtrlIsOwned<OWNED> {
         None
     }
 }
-impl<const OWNED: bool> ClassInfoMacro for HyperlinkCtrlIsOwned<OWNED> {
+impl<const OWNED: bool> DynamicCast for HyperlinkCtrlIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxHyperlinkCtrl_CLASSINFO()) }
     }
@@ -1618,7 +1618,7 @@ impl<const OWNED: bool> IconIsOwned<OWNED> {
         None
     }
 }
-impl<const OWNED: bool> ClassInfoMacro for IconIsOwned<OWNED> {
+impl<const OWNED: bool> DynamicCast for IconIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxIcon_CLASSINFO()) }
     }
@@ -1685,7 +1685,7 @@ impl<const OWNED: bool> ListBoxIsOwned<OWNED> {
         None
     }
 }
-impl<const OWNED: bool> ClassInfoMacro for ListBoxIsOwned<OWNED> {
+impl<const OWNED: bool> DynamicCast for ListBoxIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxListBox_CLASSINFO()) }
     }
@@ -1727,7 +1727,7 @@ impl<const OWNED: bool> MenuIsOwned<OWNED> {
         None
     }
 }
-impl<const OWNED: bool> ClassInfoMacro for MenuIsOwned<OWNED> {
+impl<const OWNED: bool> DynamicCast for MenuIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxMenu_CLASSINFO()) }
     }
@@ -1750,7 +1750,7 @@ impl<const OWNED: bool> MenuBarIsOwned<OWNED> {
         None
     }
 }
-impl<const OWNED: bool> ClassInfoMacro for MenuBarIsOwned<OWNED> {
+impl<const OWNED: bool> DynamicCast for MenuBarIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxMenuBar_CLASSINFO()) }
     }
@@ -1798,7 +1798,7 @@ impl<const OWNED: bool> MenuItemIsOwned<OWNED> {
         None
     }
 }
-impl<const OWNED: bool> ClassInfoMacro for MenuItemIsOwned<OWNED> {
+impl<const OWNED: bool> DynamicCast for MenuItemIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxMenuItem_CLASSINFO()) }
     }
@@ -1824,7 +1824,7 @@ impl<const OWNED: bool> NonOwnedWindowIsOwned<OWNED> {
         None
     }
 }
-impl<const OWNED: bool> ClassInfoMacro for NonOwnedWindowIsOwned<OWNED> {
+impl<const OWNED: bool> DynamicCast for NonOwnedWindowIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxNonOwnedWindow_CLASSINFO()) }
     }
@@ -1868,7 +1868,7 @@ impl<const OWNED: bool> NotebookIsOwned<OWNED> {
         None
     }
 }
-impl<const OWNED: bool> ClassInfoMacro for NotebookIsOwned<OWNED> {
+impl<const OWNED: bool> DynamicCast for NotebookIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxNotebook_CLASSINFO()) }
     }
@@ -1894,7 +1894,7 @@ impl<const OWNED: bool> NotifyEventIsOwned<OWNED> {
         None
     }
 }
-impl<const OWNED: bool> ClassInfoMacro for NotifyEventIsOwned<OWNED> {
+impl<const OWNED: bool> DynamicCast for NotifyEventIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxNotifyEvent_CLASSINFO()) }
     }
@@ -1943,7 +1943,7 @@ impl<const OWNED: bool> PanelIsOwned<OWNED> {
         None
     }
 }
-impl<const OWNED: bool> ClassInfoMacro for PanelIsOwned<OWNED> {
+impl<const OWNED: bool> DynamicCast for PanelIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxPanel_CLASSINFO()) }
     }
@@ -1987,7 +1987,7 @@ impl<const OWNED: bool> PickerBaseIsOwned<OWNED> {
         None
     }
 }
-impl<const OWNED: bool> ClassInfoMacro for PickerBaseIsOwned<OWNED> {
+impl<const OWNED: bool> DynamicCast for PickerBaseIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxPickerBase_CLASSINFO()) }
     }
@@ -2083,7 +2083,7 @@ impl<const OWNED: bool> RadioBoxIsOwned<OWNED> {
         None
     }
 }
-impl<const OWNED: bool> ClassInfoMacro for RadioBoxIsOwned<OWNED> {
+impl<const OWNED: bool> DynamicCast for RadioBoxIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxRadioBox_CLASSINFO()) }
     }
@@ -2200,7 +2200,7 @@ impl<const OWNED: bool> SizerIsOwned<OWNED> {
         None
     }
 }
-impl<const OWNED: bool> ClassInfoMacro for SizerIsOwned<OWNED> {
+impl<const OWNED: bool> DynamicCast for SizerIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxSizer_CLASSINFO()) }
     }
@@ -2274,7 +2274,7 @@ impl<const OWNED: bool> StaticBitmapIsOwned<OWNED> {
         None
     }
 }
-impl<const OWNED: bool> ClassInfoMacro for StaticBitmapIsOwned<OWNED> {
+impl<const OWNED: bool> DynamicCast for StaticBitmapIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxStaticBitmap_CLASSINFO()) }
     }
@@ -2323,7 +2323,7 @@ impl<const OWNED: bool> StaticBoxIsOwned<OWNED> {
         None
     }
 }
-impl<const OWNED: bool> ClassInfoMacro for StaticBoxIsOwned<OWNED> {
+impl<const OWNED: bool> DynamicCast for StaticBoxIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxStaticBox_CLASSINFO()) }
     }
@@ -2369,7 +2369,7 @@ impl<const OWNED: bool> StaticBoxSizerIsOwned<OWNED> {
         None
     }
 }
-impl<const OWNED: bool> ClassInfoMacro for StaticBoxSizerIsOwned<OWNED> {
+impl<const OWNED: bool> DynamicCast for StaticBoxSizerIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxStaticBoxSizer_CLASSINFO()) }
     }
@@ -2417,7 +2417,7 @@ impl<const OWNED: bool> StaticTextIsOwned<OWNED> {
         None
     }
 }
-impl<const OWNED: bool> ClassInfoMacro for StaticTextIsOwned<OWNED> {
+impl<const OWNED: bool> DynamicCast for StaticTextIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxStaticText_CLASSINFO()) }
     }
@@ -2495,7 +2495,7 @@ impl<const OWNED: bool> TextCtrlIsOwned<OWNED> {
         None
     }
 }
-impl<const OWNED: bool> ClassInfoMacro for TextCtrlIsOwned<OWNED> {
+impl<const OWNED: bool> DynamicCast for TextCtrlIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxTextCtrl_CLASSINFO()) }
     }
@@ -2546,7 +2546,7 @@ impl<const OWNED: bool> ToolBarIsOwned<OWNED> {
         None
     }
 }
-impl<const OWNED: bool> ClassInfoMacro for ToolBarIsOwned<OWNED> {
+impl<const OWNED: bool> DynamicCast for ToolBarIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxToolBar_CLASSINFO()) }
     }
@@ -2594,7 +2594,7 @@ impl<const OWNED: bool> TopLevelWindowIsOwned<OWNED> {
         None
     }
 }
-impl<const OWNED: bool> ClassInfoMacro for TopLevelWindowIsOwned<OWNED> {
+impl<const OWNED: bool> DynamicCast for TopLevelWindowIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxTopLevelWindow_CLASSINFO()) }
     }
@@ -2615,7 +2615,7 @@ impl<const OWNED: bool> ValidatorIsOwned<OWNED> {
         None
     }
 }
-impl<const OWNED: bool> ClassInfoMacro for ValidatorIsOwned<OWNED> {
+impl<const OWNED: bool> DynamicCast for ValidatorIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxValidator_CLASSINFO()) }
     }
@@ -2656,7 +2656,7 @@ impl<const OWNED: bool> WindowIsOwned<OWNED> {
         None
     }
 }
-impl<const OWNED: bool> ClassInfoMacro for WindowIsOwned<OWNED> {
+impl<const OWNED: bool> DynamicCast for WindowIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxWindow_CLASSINFO()) }
     }
@@ -2678,7 +2678,7 @@ impl<const OWNED: bool> WrapSizerIsOwned<OWNED> {
         None
     }
 }
-impl<const OWNED: bool> ClassInfoMacro for WrapSizerIsOwned<OWNED> {
+impl<const OWNED: bool> DynamicCast for WrapSizerIsOwned<OWNED> {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxWrapSizer_CLASSINFO()) }
     }

--- a/wx-core/src/generated/ffi.rs
+++ b/wx-core/src/generated/ffi.rs
@@ -5,6 +5,7 @@ pub use crate::ffi::*;
 extern "C" {
 
     // wxAnyButton
+    pub fn wxAnyButton_CLASSINFO() -> *mut c_void;
     pub fn wxAnyButton_new() -> *mut c_void;
     // DTOR: pub fn wxAnyButton_~wxAnyButton(self_: *mut c_void);
     pub fn wxAnyButton_GetBitmap(self_: *const c_void) -> *mut c_void;
@@ -25,6 +26,7 @@ extern "C" {
     pub fn wxAnyButton_SetBitmapPosition(self_: *mut c_void, dir: c_int);
 
     // wxArtProvider
+    pub fn wxArtProvider_CLASSINFO() -> *mut c_void;
     // DTOR: pub fn wxArtProvider_~wxArtProvider(self_: *mut c_void);
     pub fn wxArtProvider_Delete(provider: *mut c_void) -> bool;
     pub fn wxArtProvider_GetBitmap(
@@ -57,6 +59,7 @@ extern "C" {
     pub fn wxArtProvider_GetMessageBoxIcon(flags: c_int) -> *mut c_void;
 
     // wxBitmap
+    pub fn wxBitmap_CLASSINFO() -> *mut c_void;
     pub fn wxBitmap_new() -> *mut c_void;
     pub fn wxBitmap_new1(bitmap: *const c_void) -> *mut c_void;
     // NOT_SUPPORTED: pub fn wxBitmap_new2(bits: char, width: c_int, height: c_int, depth: c_int) -> *mut c_void;
@@ -193,6 +196,7 @@ extern "C" {
     ) -> *mut c_void;
 
     // wxBitmapButton
+    pub fn wxBitmapButton_CLASSINFO() -> *mut c_void;
     pub fn wxBitmapButton_new() -> *mut c_void;
     pub fn wxBitmapButton_new1(
         parent: *mut c_void,
@@ -228,6 +232,7 @@ extern "C" {
     ) -> *mut c_void;
 
     // wxBookCtrlBase
+    pub fn wxBookCtrlBase_CLASSINFO() -> *mut c_void;
     pub fn wxBookCtrlBase_GetPageImage(self_: *const c_void, n_page: usize) -> c_int;
     pub fn wxBookCtrlBase_SetPageImage(self_: *mut c_void, page: usize, image: c_int) -> bool;
     pub fn wxBookCtrlBase_GetPageText(self_: *const c_void, n_page: usize) -> *mut c_void;
@@ -278,6 +283,7 @@ extern "C" {
     ) -> bool;
 
     // wxBookCtrlEvent
+    pub fn wxBookCtrlEvent_CLASSINFO() -> *mut c_void;
     // NOT_SUPPORTED: pub fn wxBookCtrlEvent_new(event_type: wxEventType, id: c_int, sel: c_int, old_sel: c_int) -> *mut c_void;
     pub fn wxBookCtrlEvent_GetOldSelection(self_: *const c_void) -> c_int;
     pub fn wxBookCtrlEvent_GetSelection(self_: *const c_void) -> c_int;
@@ -285,11 +291,13 @@ extern "C" {
     pub fn wxBookCtrlEvent_SetSelection(self_: *mut c_void, page: c_int);
 
     // wxBoxSizer
+    pub fn wxBoxSizer_CLASSINFO() -> *mut c_void;
     pub fn wxBoxSizer_new(orient: c_int) -> *mut c_void;
     pub fn wxBoxSizer_GetOrientation(self_: *const c_void) -> c_int;
     pub fn wxBoxSizer_SetOrientation(self_: *mut c_void, orient: c_int);
 
     // wxButton
+    pub fn wxButton_CLASSINFO() -> *mut c_void;
     pub fn wxButton_new() -> *mut c_void;
     pub fn wxButton_new1(
         parent: *mut c_void,
@@ -318,6 +326,7 @@ extern "C" {
     pub fn wxButton_GetDefaultSize(win: *mut c_void) -> *mut c_void;
 
     // wxCheckBox
+    pub fn wxCheckBox_CLASSINFO() -> *mut c_void;
     pub fn wxCheckBox_new() -> *mut c_void;
     pub fn wxCheckBox_new1(
         parent: *mut c_void,
@@ -350,6 +359,7 @@ extern "C" {
     pub fn wxCheckBox_Set3StateValue(self_: *mut c_void, state: c_int);
 
     // wxCheckListBox
+    pub fn wxCheckListBox_CLASSINFO() -> *mut c_void;
     pub fn wxCheckListBox_new() -> *mut c_void;
     // NOT_SUPPORTED: pub fn wxCheckListBox_new1(parent: *mut c_void, id: c_int, pos: *const c_void, size: *const c_void, n: c_int, choices: wxString, style: c_long, validator: *const c_void, name: *const c_void) -> *mut c_void;
     pub fn wxCheckListBox_new2(
@@ -385,6 +395,7 @@ extern "C" {
     pub fn wxCheckListBox_AsItemContainer(obj: *mut c_void) -> *mut c_void;
 
     // wxChoice
+    pub fn wxChoice_CLASSINFO() -> *mut c_void;
     pub fn wxChoice_new() -> *mut c_void;
     // NOT_SUPPORTED: pub fn wxChoice_new1(parent: *mut c_void, id: c_int, pos: *const c_void, size: *const c_void, n: c_int, choices: wxString, style: c_long, validator: *const c_void, name: *const c_void) -> *mut c_void;
     pub fn wxChoice_new2(
@@ -418,6 +429,7 @@ extern "C" {
     pub fn wxChoice_AsItemContainer(obj: *mut c_void) -> *mut c_void;
 
     // wxColour
+    pub fn wxColour_CLASSINFO() -> *mut c_void;
     pub fn wxColour_new() -> *mut c_void;
     // NOT_SUPPORTED: pub fn wxColour_new1(red: unsigned char, green: unsigned char, blue: unsigned char, alpha: unsigned char) -> *mut c_void;
     pub fn wxColour_new2(colour_name: *const c_void) -> *mut c_void;
@@ -463,6 +475,7 @@ extern "C" {
     pub fn wxColour_ChangeLightness1(r: *mut c_void, g: *mut c_void, b: *mut c_void, ialpha: c_int);
 
     // wxColourPickerCtrl
+    pub fn wxColourPickerCtrl_CLASSINFO() -> *mut c_void;
     pub fn wxColourPickerCtrl_new() -> *mut c_void;
     pub fn wxColourPickerCtrl_new1(
         parent: *mut c_void,
@@ -490,6 +503,7 @@ extern "C" {
     // BLOCKED: pub fn wxColourPickerCtrl_SetColour1(self_: *mut c_void, colname: *const c_void);
 
     // wxComboBox
+    pub fn wxComboBox_CLASSINFO() -> *mut c_void;
     pub fn wxComboBox_new() -> *mut c_void;
     // NOT_SUPPORTED: pub fn wxComboBox_new1(parent: *mut c_void, id: c_int, value: *const c_void, pos: *const c_void, size: *const c_void, n: c_int, choices: wxString, style: c_long, validator: *const c_void, name: *const c_void) -> *mut c_void;
     pub fn wxComboBox_new2(
@@ -527,6 +541,7 @@ extern "C" {
     pub fn wxComboBox_AsTextEntry(obj: *mut c_void) -> *mut c_void;
 
     // wxCommandEvent
+    pub fn wxCommandEvent_CLASSINFO() -> *mut c_void;
     // NOT_SUPPORTED: pub fn wxCommandEvent_new(command_event_type: wxEventType, id: c_int) -> *mut c_void;
     pub fn wxCommandEvent_GetClientData(self_: *const c_void) -> *mut c_void;
     pub fn wxCommandEvent_GetClientObject(self_: *const c_void) -> *mut c_void;
@@ -543,6 +558,7 @@ extern "C" {
     pub fn wxCommandEvent_SetString(self_: *mut c_void, string: *const c_void);
 
     // wxControl
+    pub fn wxControl_CLASSINFO() -> *mut c_void;
     pub fn wxControl_new(
         parent: *mut c_void,
         id: c_int,
@@ -589,6 +605,7 @@ extern "C" {
     ) -> *mut c_void;
 
     // wxDatePickerCtrl
+    pub fn wxDatePickerCtrl_CLASSINFO() -> *mut c_void;
     pub fn wxDatePickerCtrl_new() -> *mut c_void;
     pub fn wxDatePickerCtrl_new1(
         parent: *mut c_void,
@@ -622,6 +639,7 @@ extern "C" {
     pub fn wxDatePickerCtrl_SetValue(self_: *mut c_void, dt: *const c_void);
 
     // wxDirPickerCtrl
+    pub fn wxDirPickerCtrl_CLASSINFO() -> *mut c_void;
     pub fn wxDirPickerCtrl_new() -> *mut c_void;
     pub fn wxDirPickerCtrl_new1(
         parent: *mut c_void,
@@ -653,6 +671,7 @@ extern "C" {
     pub fn wxDirPickerCtrl_SetPath(self_: *mut c_void, dirname: *const c_void);
 
     // wxEditableListBox
+    pub fn wxEditableListBox_CLASSINFO() -> *mut c_void;
     pub fn wxEditableListBox_new() -> *mut c_void;
     pub fn wxEditableListBox_new1(
         parent: *mut c_void,
@@ -678,6 +697,7 @@ extern "C" {
     pub fn wxEditableListBox_GetStrings(self_: *const c_void, strings: *mut c_void);
 
     // wxFileCtrl
+    pub fn wxFileCtrl_CLASSINFO() -> *mut c_void;
     pub fn wxFileCtrl_new() -> *mut c_void;
     pub fn wxFileCtrl_new1(
         parent: *mut c_void,
@@ -717,6 +737,7 @@ extern "C" {
     pub fn wxFileCtrl_ShowHidden(self_: *mut c_void, show: bool);
 
     // wxFont
+    pub fn wxFont_CLASSINFO() -> *mut c_void;
     pub fn wxFont_GetBaseFont(self_: *const c_void) -> *mut c_void;
     // NOT_SUPPORTED: pub fn wxFont_GetEncoding(self_: *const c_void) -> wxFontEncoding;
     pub fn wxFont_GetFaceName(self_: *const c_void) -> *mut c_void;
@@ -787,6 +808,7 @@ extern "C" {
     // DTOR: pub fn wxFont_~wxFont(self_: *mut c_void);
 
     // wxFontPickerCtrl
+    pub fn wxFontPickerCtrl_CLASSINFO() -> *mut c_void;
     pub fn wxFontPickerCtrl_new() -> *mut c_void;
     pub fn wxFontPickerCtrl_new1(
         parent: *mut c_void,
@@ -819,6 +841,7 @@ extern "C" {
     pub fn wxFontPickerCtrl_SetSelectedFont(self_: *mut c_void, font: *const c_void);
 
     // wxFrame
+    pub fn wxFrame_CLASSINFO() -> *mut c_void;
     pub fn wxFrame_new() -> *mut c_void;
     pub fn wxFrame_new1(
         parent: *mut c_void,
@@ -884,9 +907,11 @@ extern "C" {
     pub fn wxFrame_PopStatusText(self_: *mut c_void, number: c_int);
 
     // wxGDIObject
+    pub fn wxGDIObject_CLASSINFO() -> *mut c_void;
     // BLOCKED: pub fn wxGDIObject_new() -> *mut c_void;
 
     // wxGauge
+    pub fn wxGauge_CLASSINFO() -> *mut c_void;
     pub fn wxGauge_new() -> *mut c_void;
     pub fn wxGauge_new1(
         parent: *mut c_void,
@@ -918,6 +943,7 @@ extern "C" {
     pub fn wxGauge_SetValue(self_: *mut c_void, pos: c_int);
 
     // wxGenericDirCtrl
+    pub fn wxGenericDirCtrl_CLASSINFO() -> *mut c_void;
     pub fn wxGenericDirCtrl_new() -> *mut c_void;
     pub fn wxGenericDirCtrl_new1(
         parent: *mut c_void,
@@ -1002,6 +1028,7 @@ extern "C" {
     ) -> *mut c_void;
 
     // wxHeaderCtrl
+    pub fn wxHeaderCtrl_CLASSINFO() -> *mut c_void;
     // BLOCKED: pub fn wxHeaderCtrl_new() -> *mut c_void;
     // BLOCKED: pub fn wxHeaderCtrl_new1(parent: *mut c_void, winid: c_int, pos: *const c_void, size: *const c_void, style: c_long, name: *const c_void) -> *mut c_void;
     pub fn wxHeaderCtrl_Create(
@@ -1038,6 +1065,7 @@ extern "C" {
     pub fn wxHeaderCtrl_MoveColumnInOrderArray(order: *mut c_void, idx: c_uint, pos: c_uint);
 
     // wxHeaderCtrlSimple
+    pub fn wxHeaderCtrlSimple_CLASSINFO() -> *mut c_void;
     pub fn wxHeaderCtrlSimple_new() -> *mut c_void;
     pub fn wxHeaderCtrlSimple_new1(
         parent: *mut c_void,
@@ -1056,6 +1084,7 @@ extern "C" {
     pub fn wxHeaderCtrlSimple_RemoveSortIndicator(self_: *mut c_void);
 
     // wxHyperlinkCtrl
+    pub fn wxHyperlinkCtrl_CLASSINFO() -> *mut c_void;
     pub fn wxHyperlinkCtrl_new() -> *mut c_void;
     pub fn wxHyperlinkCtrl_new1(
         parent: *mut c_void,
@@ -1090,6 +1119,7 @@ extern "C" {
     pub fn wxHyperlinkCtrl_SetVisitedColour(self_: *mut c_void, colour: *const c_void);
 
     // wxIcon
+    pub fn wxIcon_CLASSINFO() -> *mut c_void;
     pub fn wxIcon_new() -> *mut c_void;
     pub fn wxIcon_new1(icon: *const c_void) -> *mut c_void;
     // NOT_SUPPORTED: pub fn wxIcon_new2(bits: char, width: c_int, height: c_int) -> *mut c_void;
@@ -1251,6 +1281,7 @@ extern "C" {
     ) -> c_int;
 
     // wxListBox
+    pub fn wxListBox_CLASSINFO() -> *mut c_void;
     pub fn wxListBox_new() -> *mut c_void;
     // NOT_SUPPORTED: pub fn wxListBox_new1(parent: *mut c_void, id: c_int, pos: *const c_void, size: *const c_void, n: c_int, choices: wxString, style: c_long, validator: *const c_void, name: *const c_void) -> *mut c_void;
     pub fn wxListBox_new2(
@@ -1297,6 +1328,7 @@ extern "C" {
     pub fn wxListBox_AsItemContainer(obj: *mut c_void) -> *mut c_void;
 
     // wxMenu
+    pub fn wxMenu_CLASSINFO() -> *mut c_void;
     pub fn wxMenu_new() -> *mut c_void;
     pub fn wxMenu_new1(style: c_long) -> *mut c_void;
     pub fn wxMenu_new2(title: *const c_void, style: c_long) -> *mut c_void;
@@ -1433,6 +1465,7 @@ extern "C" {
     pub fn wxMenu_IsAttached(self_: *const c_void) -> bool;
 
     // wxMenuBar
+    pub fn wxMenuBar_CLASSINFO() -> *mut c_void;
     pub fn wxMenuBar_new(style: c_long) -> *mut c_void;
     // NOT_SUPPORTED: pub fn wxMenuBar_new1(n: usize, menus: *mut c_void, titles: wxString, style: c_long) -> *mut c_void;
     // DTOR: pub fn wxMenuBar_~wxMenuBar(self_: *mut c_void);
@@ -1483,6 +1516,7 @@ extern "C" {
     pub fn wxMenuBar_MacGetCommonMenuBar() -> *mut c_void;
 
     // wxMenuItem
+    pub fn wxMenuItem_CLASSINFO() -> *mut c_void;
     // BLOCKED: pub fn wxMenuItem_GetBackgroundColour(self_: *const c_void) -> *mut c_void;
     pub fn wxMenuItem_GetBitmap(self_: *const c_void) -> *mut c_void;
     pub fn wxMenuItem_GetBitmap1(self_: *const c_void, checked: bool) -> *mut c_void;
@@ -1545,10 +1579,12 @@ extern "C" {
     pub fn wxMenuItem_GetLabelText(text: *const c_void) -> *mut c_void;
 
     // wxNonOwnedWindow
+    pub fn wxNonOwnedWindow_CLASSINFO() -> *mut c_void;
     pub fn wxNonOwnedWindow_SetShape(self_: *mut c_void, region: *const c_void) -> bool;
     pub fn wxNonOwnedWindow_SetShape1(self_: *mut c_void, path: *const c_void) -> bool;
 
     // wxNotebook
+    pub fn wxNotebook_CLASSINFO() -> *mut c_void;
     pub fn wxNotebook_new() -> *mut c_void;
     pub fn wxNotebook_new1(
         parent: *mut c_void,
@@ -1566,12 +1602,14 @@ extern "C" {
     pub fn wxNotebook_SetPadding(self_: *mut c_void, padding: *const c_void);
 
     // wxNotifyEvent
+    pub fn wxNotifyEvent_CLASSINFO() -> *mut c_void;
     // NOT_SUPPORTED: pub fn wxNotifyEvent_new(event_type: wxEventType, id: c_int) -> *mut c_void;
     pub fn wxNotifyEvent_Allow(self_: *mut c_void);
     pub fn wxNotifyEvent_IsAllowed(self_: *const c_void) -> bool;
     pub fn wxNotifyEvent_Veto(self_: *mut c_void);
 
     // wxPanel
+    pub fn wxPanel_CLASSINFO() -> *mut c_void;
     pub fn wxPanel_new() -> *mut c_void;
     pub fn wxPanel_new1(
         parent: *mut c_void,
@@ -1595,6 +1633,7 @@ extern "C" {
     pub fn wxPanel_SetFocusIgnoringChildren(self_: *mut c_void);
 
     // wxPickerBase
+    pub fn wxPickerBase_CLASSINFO() -> *mut c_void;
     // BLOCKED: pub fn wxPickerBase_new() -> *mut c_void;
     // DTOR: pub fn wxPickerBase_~wxPickerBase(self_: *mut c_void);
     pub fn wxPickerBase_CreateBase(
@@ -1653,6 +1692,7 @@ extern "C" {
     pub fn wxPoint_new2(pt: *const c_void) -> *mut c_void;
 
     // wxRadioBox
+    pub fn wxRadioBox_CLASSINFO() -> *mut c_void;
     pub fn wxRadioBox_new() -> *mut c_void;
     // NOT_SUPPORTED: pub fn wxRadioBox_new1(parent: *mut c_void, id: c_int, label: *const c_void, pos: *const c_void, size: *const c_void, n: c_int, choices: wxString, major_dimension: c_int, style: c_long, validator: *const c_void, name: *const c_void) -> *mut c_void;
     pub fn wxRadioBox_new2(
@@ -1822,6 +1862,7 @@ extern "C" {
     pub fn wxSize_SetWidth(self_: *mut c_void, width: c_int);
 
     // wxSizer
+    pub fn wxSizer_CLASSINFO() -> *mut c_void;
     // BLOCKED: pub fn wxSizer_new() -> *mut c_void;
     // DTOR: pub fn wxSizer_~wxSizer(self_: *mut c_void);
     pub fn wxSizer_Add(
@@ -2111,6 +2152,7 @@ extern "C" {
     // NOT_SUPPORTED: pub fn wxSizerFlags_GetDefaultBorderFractional() -> float;
 
     // wxStaticBitmap
+    pub fn wxStaticBitmap_CLASSINFO() -> *mut c_void;
     pub fn wxStaticBitmap_new() -> *mut c_void;
     pub fn wxStaticBitmap_new1(
         parent: *mut c_void,
@@ -2139,6 +2181,7 @@ extern "C" {
     // NOT_SUPPORTED: pub fn wxStaticBitmap_GetScaleMode(self_: *const c_void) -> ScaleMode;
 
     // wxStaticBox
+    pub fn wxStaticBox_CLASSINFO() -> *mut c_void;
     pub fn wxStaticBox_new() -> *mut c_void;
     pub fn wxStaticBox_new1(
         parent: *mut c_void,
@@ -2164,6 +2207,7 @@ extern "C" {
     // BLOCKED: pub fn wxStaticBox_Create1(self_: *mut c_void, parent: *mut c_void, id: c_int, label: *mut c_void, pos: *const c_void, size: *const c_void, style: c_long, name: *const c_void) -> bool;
 
     // wxStaticBoxSizer
+    pub fn wxStaticBoxSizer_CLASSINFO() -> *mut c_void;
     pub fn wxStaticBoxSizer_new(box_: *mut c_void, orient: c_int) -> *mut c_void;
     pub fn wxStaticBoxSizer_new1(
         orient: c_int,
@@ -2173,6 +2217,7 @@ extern "C" {
     pub fn wxStaticBoxSizer_GetStaticBox(self_: *const c_void) -> *mut c_void;
 
     // wxStaticText
+    pub fn wxStaticText_CLASSINFO() -> *mut c_void;
     pub fn wxStaticText_new() -> *mut c_void;
     pub fn wxStaticText_new1(
         parent: *mut c_void,
@@ -2319,6 +2364,7 @@ extern "C" {
     pub fn wxTextAttr_Merge1(base: *const c_void, overlay: *const c_void) -> *mut c_void;
 
     // wxTextCtrl
+    pub fn wxTextCtrl_CLASSINFO() -> *mut c_void;
     pub fn wxTextCtrl_OSXEnableNewLineReplacement(self_: *mut c_void, enable: bool);
     // BLOCKED: pub fn wxTextCtrl_operator<<(self_: *mut c_void, s: *const c_void) -> *mut c_void;
     // BLOCKED: pub fn wxTextCtrl_operator<<1(self_: *mut c_void, i: c_int) -> *mut c_void;
@@ -2443,6 +2489,7 @@ extern "C" {
     pub fn wxTextEntry_WriteText(self_: *mut c_void, text: *const c_void);
 
     // wxToolBar
+    pub fn wxToolBar_CLASSINFO() -> *mut c_void;
     pub fn wxToolBar_new() -> *mut c_void;
     pub fn wxToolBar_new1(
         parent: *mut c_void,
@@ -2586,6 +2633,7 @@ extern "C" {
     pub fn wxToolBar_CreateSeparator(self_: *mut c_void) -> *mut c_void;
 
     // wxTopLevelWindow
+    pub fn wxTopLevelWindow_CLASSINFO() -> *mut c_void;
     pub fn wxTopLevelWindow_new() -> *mut c_void;
     pub fn wxTopLevelWindow_new1(
         parent: *mut c_void,
@@ -2653,6 +2701,7 @@ extern "C" {
     pub fn wxTopLevelWindow_GetDefaultSize() -> *mut c_void;
 
     // wxValidator
+    pub fn wxValidator_CLASSINFO() -> *mut c_void;
     pub fn wxValidator_new() -> *mut c_void;
     // DTOR: pub fn wxValidator_~wxValidator(self_: *mut c_void);
     pub fn wxValidator_Clone(self_: *const c_void) -> *mut c_void;
@@ -2665,6 +2714,7 @@ extern "C" {
     pub fn wxValidator_IsSilent() -> bool;
 
     // wxWindow
+    pub fn wxWindow_CLASSINFO() -> *mut c_void;
     pub fn wxWindow_AcceptsFocus(self_: *const c_void) -> bool;
     pub fn wxWindow_AcceptsFocusFromKeyboard(self_: *const c_void) -> bool;
     pub fn wxWindow_AcceptsFocusRecursively(self_: *const c_void) -> bool;
@@ -3053,6 +3103,7 @@ extern "C" {
     ) -> bool;
 
     // wxWrapSizer
+    pub fn wxWrapSizer_CLASSINFO() -> *mut c_void;
     pub fn wxWrapSizer_new(orient: c_int, flags: c_int) -> *mut c_void;
 
 }

--- a/wx-core/src/lib.rs
+++ b/wx-core/src/lib.rs
@@ -47,7 +47,7 @@ pub mod methods {
         fn sub_menu<M: MenuMethods>(self, s: &str, submenu: &M) -> Self;
         fn separator(self) -> Self;
     }
-
+    
     pub trait ClassInfoMacro: ObjectMethods {
         fn class_info() -> ClassInfoIsOwned<false>;
     }
@@ -1781,6 +1781,22 @@ impl From<Bitmap> for BitmapBundle {
 impl ClassInfoMacro for CheckListBox {
     fn class_info() -> ClassInfoIsOwned<false> {
         unsafe { ClassInfoIsOwned::from_ptr(ffi::wxCheckListBox_CLASSINFO()) }
+    }
+}
+
+impl<const OWNED: bool> From<CheckListBoxIsOwned<OWNED>> for ListBoxIsOwned<OWNED> {
+    fn from(o: CheckListBoxIsOwned<OWNED>) -> Self {
+        unsafe { ListBoxIsOwned::from_ptr(o.as_ptr()) }
+    }
+}
+impl<const OWNED: bool> TryFrom<&ListBoxIsOwned<OWNED>> for CheckListBoxIsOwned<false> {
+    type Error = ();
+    fn try_from(lbox: &ListBoxIsOwned<OWNED>) -> Result<Self, Self::Error> {
+        if lbox.is_kind_of(Some(&CheckListBox::class_info())) {
+            unsafe { Ok(CheckListBox::from_unowned_ptr(lbox.as_ptr())) }
+        } else {
+            Err(())
+        }
     }
 }
 

--- a/wx-core/src/lib.rs
+++ b/wx-core/src/lib.rs
@@ -47,10 +47,6 @@ pub mod methods {
         fn sub_menu<M: MenuMethods>(self, s: &str, submenu: &M) -> Self;
         fn separator(self) -> Self;
     }
-    
-    pub trait ClassInfoMacro: ObjectMethods {
-        fn class_info() -> ClassInfoIsOwned<false>;
-    }
 }
 use methods::*;
 
@@ -73,9 +69,6 @@ mod ffi {
 
         // wxBitmapBundle compatibility hack(for a while)
         pub fn wxBitmapBundle_From(bitmap: *mut c_void) -> *mut c_void;
-
-        // wxCLASSINFO()
-        pub fn wxCheckListBox_CLASSINFO() -> *mut c_void;
 
         pub fn wxRustMessageBox(
             message: *const c_void,
@@ -1774,13 +1767,6 @@ impl<const OWNED: bool> Drop for WindowListIsOwned<OWNED> {
 impl From<Bitmap> for BitmapBundle {
     fn from(bitmap: Bitmap) -> Self {
         unsafe { BitmapBundle::from_ptr(ffi::wxBitmapBundle_From(bitmap.as_ptr())) }
-    }
-}
-
-// wxCLASSINFO()
-impl ClassInfoMacro for CheckListBox {
-    fn class_info() -> ClassInfoIsOwned<false> {
-        unsafe { ClassInfoIsOwned::from_ptr(ffi::wxCheckListBox_CLASSINFO()) }
     }
 }
 

--- a/wx-core/src/lib.rs
+++ b/wx-core/src/lib.rs
@@ -1770,12 +1770,6 @@ impl From<Bitmap> for BitmapBundle {
     }
 }
 
-impl<const OWNED: bool> From<CheckListBoxIsOwned<OWNED>> for ListBoxIsOwned<OWNED> {
-    fn from(o: CheckListBoxIsOwned<OWNED>) -> Self {
-        unsafe { ListBoxIsOwned::from_ptr(o.as_ptr()) }
-    }
-}
-
 // FIXME: wxWindowUpdateLocker shim for wx3.0.x
 // TODO: use generated code once dropped wx3.0.x support
 pub struct WindowUpdateLocker<'a, T: WindowMethods>(Option<&'a T>);

--- a/wx-core/src/lib.rs
+++ b/wx-core/src/lib.rs
@@ -1775,16 +1775,6 @@ impl<const OWNED: bool> From<CheckListBoxIsOwned<OWNED>> for ListBoxIsOwned<OWNE
         unsafe { ListBoxIsOwned::from_ptr(o.as_ptr()) }
     }
 }
-impl<const OWNED: bool> TryFrom<&ListBoxIsOwned<OWNED>> for CheckListBoxIsOwned<false> {
-    type Error = ();
-    fn try_from(lbox: &ListBoxIsOwned<OWNED>) -> Result<Self, Self::Error> {
-        if lbox.is_kind_of(Some(&CheckListBox::class_info())) {
-            unsafe { Ok(CheckListBox::from_unowned_ptr(lbox.as_ptr())) }
-        } else {
-            Err(())
-        }
-    }
-}
 
 // FIXME: wxWindowUpdateLocker shim for wx3.0.x
 // TODO: use generated code once dropped wx3.0.x support

--- a/wx-core/src/manual.cpp
+++ b/wx-core/src/manual.cpp
@@ -29,11 +29,6 @@ void *wxBitmapBundle_From(wxBitmap *bitmap) {
 #endif
 }
 
-// wxCLASSINFO()
-wxClassInfo *wxCheckListBox_CLASSINFO() {
-    return wxCLASSINFO(wxCheckListBox);
-}
-
 int wxRustMessageBox(const wxString *message, const wxString *caption, int style, wxWindow *parent, int x, int y) {
     return wxMessageBox(*message, *caption, style, parent, x, y);
 }


### PR DESCRIPTION
Close  #107

* Safe upcasting
    * From trait impls to convert to ancestor classes (except mix-in classes)
* Safe downcasting
    * wxObject-derived classes impl DynamicCast trait which support dynamic cast with `as_unowned<wx::Class>`