### PR TITLE
Fix license notation in samples/ subdirectory

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,7 @@ Specify `--features vendored` to cargo, to use vendored prebuilt wx binary crate
 [MIT License](https://opensource.org/licenses/mit-license.php). but you can (and shoudld) treat this library as [wxWindows Library Licence](https://www.wxwidgets.org/about/licence/) (same with required wxWidgets library dependency).
 
 Large part of this project is the binding generator in Python (doxybindgen). This part may be usable and want to be used for another traditional C++ APIs with Doxygen documented (c.f. like Haiku OS APIs(Kits)) in future. So permissive license is desirable.
+
+### Samples ported from wxWidgets
+
+[samples/](./samples/) subdirectory contains sample codes ported from the wxWidgets Library. These sample codes are licensed under the [wxWindows Library Licence](https://www.wxwidgets.org/about/licence/).

--- a/samples/LICENSE
+++ b/samples/LICENSE
@@ -1,0 +1,53 @@
+                wxWindows Library Licence, Version 3.1
+                ======================================
+
+  Copyright (c) 1998-2005 Julian Smart, Robert Roebling et al
+
+  Everyone is permitted to copy and distribute verbatim copies
+  of this licence document, but changing it is not allowed.
+
+                       WXWINDOWS LIBRARY LICENCE
+     TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  This library is free software; you can redistribute it and/or modify it
+  under the terms of the GNU Library General Public Licence as published by
+  the Free Software Foundation; either version 2 of the Licence, or (at
+  your option) any later version.
+
+  This library is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Library
+  General Public Licence for more details.
+
+  You should have received a copy of the GNU Library General Public Licence
+  along with this software, usually in a file named COPYING.LIB.  If not,
+  write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+  Boston, MA 02110-1301 USA.
+
+  EXCEPTION NOTICE
+
+  1. As a special exception, the copyright holders of this library give
+  permission for additional uses of the text contained in this release of
+  the library as licenced under the wxWindows Library Licence, applying
+  either version 3.1 of the Licence, or (at your option) any later version of
+  the Licence as published by the copyright holders of version
+  3.1 of the Licence document.
+
+  2. The exception is that you may use, copy, link, modify and distribute
+  under your own terms, binary object code versions of works based
+  on the Library.
+
+  3. If you copy code from files distributed under the terms of the GNU
+  General Public Licence or the GNU Library General Public Licence into a
+  copy of this library, as this licence permits, the exception does not
+  apply to the code that you add in this way.  To avoid misleading anyone as
+  to the status of such modified files, you must delete this exception
+  notice from such code and/or adjust the licensing conditions notice
+  accordingly.
+
+  4. If you write modifications of your own for this library, it is your
+  choice whether to permit this exception to apply to your modifications.
+  If you do not wish that, you must delete the exception notice from such
+  code and/or adjust the licensing conditions notice accordingly.
+
+

--- a/samples/hello/src/main.rs
+++ b/samples/hello/src/main.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+//
 // wxRust2 Hello World Sample.
 // Created by:  KENZ<KENZ.gelsoft@gmail.com>
 

--- a/samples/hello/src/main.rs
+++ b/samples/hello/src/main.rs
@@ -1,3 +1,6 @@
+// wxRust2 Hello World Sample.
+// Created by:  KENZ<KENZ.gelsoft@gmail.com>
+
 #![windows_subsystem = "windows"]
 
 use wx;

--- a/samples/minimal/src/main.rs
+++ b/samples/minimal/src/main.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.0-or-later WITH WxWindows-exception-3.1
+//
 // wxWidgets Sample (partially/incompletely) ported in Rust.
 // Ported by:   KENZ<KENZ.gelsoft@gmail.com>
 // Original C++ Version's Copyright is:
@@ -8,7 +10,6 @@
 // Modified by:
 // Created:     04/01/98
 // Copyright:   (c) Julian Smart
-// Licence:     wxWindows licence
 /////////////////////////////////////////////////////////////////////////////
 
 #![windows_subsystem = "windows"]

--- a/samples/minimal/src/main.rs
+++ b/samples/minimal/src/main.rs
@@ -1,3 +1,6 @@
+// wxWidgets Sample (partially/incompletely) ported in Rust.
+// Ported by:   KENZ<KENZ.gelsoft@gmail.com>
+// Original C++ Version's Copyright is:
 /////////////////////////////////////////////////////////////////////////////
 // Name:        minimal.cpp
 // Purpose:     Minimal wxWidgets sample

--- a/samples/minimal/src/main.rs
+++ b/samples/minimal/src/main.rs
@@ -1,3 +1,13 @@
+/////////////////////////////////////////////////////////////////////////////
+// Name:        minimal.cpp
+// Purpose:     Minimal wxWidgets sample
+// Author:      Julian Smart
+// Modified by:
+// Created:     04/01/98
+// Copyright:   (c) Julian Smart
+// Licence:     wxWindows licence
+/////////////////////////////////////////////////////////////////////////////
+
 #![windows_subsystem = "windows"]
 
 use std::os::raw::{c_int, c_long};

--- a/samples/widgets/src/activityindicator.rs
+++ b/samples/widgets/src/activityindicator.rs
@@ -1,3 +1,13 @@
+/////////////////////////////////////////////////////////////////////////////
+// Program:     wxWidgets Widgets Sample
+// Name:        activityindicator.cpp
+// Purpose:     Part of the widgets sample showing wxActivityIndicator
+// Author:      Vadim Zeitlin
+// Created:     2015-03-06
+// Copyright:   (c) 2015 wxWindows team
+// Licence:     wxWindows licence
+/////////////////////////////////////////////////////////////////////////////
+
 use std::os::raw::c_int;
 use wx::methods::*;
 

--- a/samples/widgets/src/activityindicator.rs
+++ b/samples/widgets/src/activityindicator.rs
@@ -1,3 +1,6 @@
+// wxWidgets Sample (partially/incompletely) ported in Rust.
+// Ported by:   KENZ<KENZ.gelsoft@gmail.com>
+// Original C++ Version's Copyright is:
 /////////////////////////////////////////////////////////////////////////////
 // Program:     wxWidgets Widgets Sample
 // Name:        activityindicator.cpp

--- a/samples/widgets/src/activityindicator.rs
+++ b/samples/widgets/src/activityindicator.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.0-or-later WITH WxWindows-exception-3.1
+//
 // wxWidgets Sample (partially/incompletely) ported in Rust.
 // Ported by:   KENZ<KENZ.gelsoft@gmail.com>
 // Original C++ Version's Copyright is:
@@ -8,7 +10,6 @@
 // Author:      Vadim Zeitlin
 // Created:     2015-03-06
 // Copyright:   (c) 2015 wxWindows team
-// Licence:     wxWindows licence
 /////////////////////////////////////////////////////////////////////////////
 
 use std::os::raw::c_int;

--- a/samples/widgets/src/button.rs
+++ b/samples/widgets/src/button.rs
@@ -1,3 +1,13 @@
+/////////////////////////////////////////////////////////////////////////////
+// Program:     wxWidgets Widgets Sample
+// Name:        button.cpp
+// Purpose:     Part of the widgets sample showing wxButton
+// Author:      Vadim Zeitlin
+// Created:     10.04.01
+// Copyright:   (c) 2001 Vadim Zeitlin
+// Licence:     wxWindows licence
+/////////////////////////////////////////////////////////////////////////////
+
 use crate::WidgetsPage;
 use std::cell::RefCell;
 use std::os::raw::{c_int, c_long};

--- a/samples/widgets/src/button.rs
+++ b/samples/widgets/src/button.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.0-or-later WITH WxWindows-exception-3.1
+//
 // wxWidgets Sample (partially/incompletely) ported in Rust.
 // Ported by:   KENZ<KENZ.gelsoft@gmail.com>
 // Original C++ Version's Copyright is:
@@ -8,7 +10,6 @@
 // Author:      Vadim Zeitlin
 // Created:     10.04.01
 // Copyright:   (c) 2001 Vadim Zeitlin
-// Licence:     wxWindows licence
 /////////////////////////////////////////////////////////////////////////////
 
 use crate::WidgetsPage;

--- a/samples/widgets/src/button.rs
+++ b/samples/widgets/src/button.rs
@@ -1,3 +1,6 @@
+// wxWidgets Sample (partially/incompletely) ported in Rust.
+// Ported by:   KENZ<KENZ.gelsoft@gmail.com>
+// Original C++ Version's Copyright is:
 /////////////////////////////////////////////////////////////////////////////
 // Program:     wxWidgets Widgets Sample
 // Name:        button.cpp

--- a/samples/widgets/src/checkbox.rs
+++ b/samples/widgets/src/checkbox.rs
@@ -1,3 +1,13 @@
+/////////////////////////////////////////////////////////////////////////////
+// Program:     wxWidgets Widgets Sample
+// Name:        checkbox.cpp
+// Purpose:     Part of the widgets sample showing wxCheckBox
+// Author:      Dimitri Schoolwerth, Vadim Zeitlin
+// Created:     27 Sep 2003
+// Copyright:   (c) 2003 wxWindows team
+// Licence:     wxWindows licence
+/////////////////////////////////////////////////////////////////////////////
+
 use crate::WidgetsPage;
 use std::cell::RefCell;
 use std::os::raw::{c_int, c_long};

--- a/samples/widgets/src/checkbox.rs
+++ b/samples/widgets/src/checkbox.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.0-or-later WITH WxWindows-exception-3.1
+//
 // wxWidgets Sample (partially/incompletely) ported in Rust.
 // Ported by:   KENZ<KENZ.gelsoft@gmail.com>
 // Original C++ Version's Copyright is:
@@ -8,7 +10,6 @@
 // Author:      Dimitri Schoolwerth, Vadim Zeitlin
 // Created:     27 Sep 2003
 // Copyright:   (c) 2003 wxWindows team
-// Licence:     wxWindows licence
 /////////////////////////////////////////////////////////////////////////////
 
 use crate::WidgetsPage;

--- a/samples/widgets/src/checkbox.rs
+++ b/samples/widgets/src/checkbox.rs
@@ -1,3 +1,6 @@
+// wxWidgets Sample (partially/incompletely) ported in Rust.
+// Ported by:   KENZ<KENZ.gelsoft@gmail.com>
+// Original C++ Version's Copyright is:
 /////////////////////////////////////////////////////////////////////////////
 // Program:     wxWidgets Widgets Sample
 // Name:        checkbox.cpp

--- a/samples/widgets/src/choice.rs
+++ b/samples/widgets/src/choice.rs
@@ -1,3 +1,11 @@
+/////////////////////////////////////////////////////////////////////////////
+// Program:     wxWidgets Widgets Sample
+// Name:        choice.cpp
+// Purpose:     Part of the widgets sample showing wxChoice
+// Created:     23.07.07
+// Licence:     wxWindows licence
+/////////////////////////////////////////////////////////////////////////////
+
 use crate::WidgetsPage;
 use std::cell::RefCell;
 use std::os::raw::{c_int, c_long};

--- a/samples/widgets/src/choice.rs
+++ b/samples/widgets/src/choice.rs
@@ -1,3 +1,6 @@
+// wxWidgets Sample (partially/incompletely) ported in Rust.
+// Ported by:   KENZ<KENZ.gelsoft@gmail.com>
+// Original C++ Version's Copyright is:
 /////////////////////////////////////////////////////////////////////////////
 // Program:     wxWidgets Widgets Sample
 // Name:        choice.cpp

--- a/samples/widgets/src/choice.rs
+++ b/samples/widgets/src/choice.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.0-or-later WITH WxWindows-exception-3.1
+//
 // wxWidgets Sample (partially/incompletely) ported in Rust.
 // Ported by:   KENZ<KENZ.gelsoft@gmail.com>
 // Original C++ Version's Copyright is:
@@ -6,7 +8,6 @@
 // Name:        choice.cpp
 // Purpose:     Part of the widgets sample showing wxChoice
 // Created:     23.07.07
-// Licence:     wxWindows licence
 /////////////////////////////////////////////////////////////////////////////
 
 use crate::WidgetsPage;

--- a/samples/widgets/src/clrpicker.rs
+++ b/samples/widgets/src/clrpicker.rs
@@ -1,3 +1,6 @@
+// wxWidgets Sample (partially/incompletely) ported in Rust.
+// Ported by:   KENZ<KENZ.gelsoft@gmail.com>
+// Original C++ Version's Copyright is:
 /////////////////////////////////////////////////////////////////////////////
 // Program:     wxWidgets Widgets Sample
 // Name:        clrpicker.cpp

--- a/samples/widgets/src/clrpicker.rs
+++ b/samples/widgets/src/clrpicker.rs
@@ -1,3 +1,13 @@
+/////////////////////////////////////////////////////////////////////////////
+// Program:     wxWidgets Widgets Sample
+// Name:        clrpicker.cpp
+// Purpose:     Shows wxColourPickerCtrl
+// Author:      Francesco Montorsi
+// Created:     20/6/2006
+// Copyright:   (c) 2006 Francesco Montorsi
+// Licence:     wxWindows licence
+/////////////////////////////////////////////////////////////////////////////
+
 use crate::WidgetsPage;
 use std::cell::RefCell;
 use std::os::raw::{c_int, c_long};

--- a/samples/widgets/src/clrpicker.rs
+++ b/samples/widgets/src/clrpicker.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.0-or-later WITH WxWindows-exception-3.1
+//
 // wxWidgets Sample (partially/incompletely) ported in Rust.
 // Ported by:   KENZ<KENZ.gelsoft@gmail.com>
 // Original C++ Version's Copyright is:
@@ -8,7 +10,6 @@
 // Author:      Francesco Montorsi
 // Created:     20/6/2006
 // Copyright:   (c) 2006 Francesco Montorsi
-// Licence:     wxWindows licence
 /////////////////////////////////////////////////////////////////////////////
 
 use crate::WidgetsPage;

--- a/samples/widgets/src/combobox.rs
+++ b/samples/widgets/src/combobox.rs
@@ -1,3 +1,6 @@
+// wxWidgets Sample (partially/incompletely) ported in Rust.
+// Ported by:   KENZ<KENZ.gelsoft@gmail.com>
+// Original C++ Version's Copyright is:
 /////////////////////////////////////////////////////////////////////////////
 // Program:     wxWidgets Widgets Sample
 // Name:        combobox.cpp

--- a/samples/widgets/src/combobox.rs
+++ b/samples/widgets/src/combobox.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.0-or-later WITH WxWindows-exception-3.1
+//
 // wxWidgets Sample (partially/incompletely) ported in Rust.
 // Ported by:   KENZ<KENZ.gelsoft@gmail.com>
 // Original C++ Version's Copyright is:
@@ -8,7 +10,6 @@
 // Author:      Vadim Zeitlin
 // Created:     27.03.01
 // Copyright:   (c) 2001 Vadim Zeitlin
-// Licence:     wxWindows licence
 /////////////////////////////////////////////////////////////////////////////
 
 use crate::WidgetsPage;

--- a/samples/widgets/src/combobox.rs
+++ b/samples/widgets/src/combobox.rs
@@ -1,3 +1,13 @@
+/////////////////////////////////////////////////////////////////////////////
+// Program:     wxWidgets Widgets Sample
+// Name:        combobox.cpp
+// Purpose:     Part of the widgets sample showing wxComboBox
+// Author:      Vadim Zeitlin
+// Created:     27.03.01
+// Copyright:   (c) 2001 Vadim Zeitlin
+// Licence:     wxWindows licence
+/////////////////////////////////////////////////////////////////////////////
+
 use crate::WidgetsPage;
 use std::cell::RefCell;
 use std::os::raw::{c_int, c_long};

--- a/samples/widgets/src/datepicker.rs
+++ b/samples/widgets/src/datepicker.rs
@@ -1,3 +1,6 @@
+// wxWidgets Sample (partially/incompletely) ported in Rust.
+// Ported by:   KENZ<KENZ.gelsoft@gmail.com>
+// Original C++ Version's Copyright is:
 /////////////////////////////////////////////////////////////////////////////
 // Program:     wxWidgets Widgets Sample
 // Name:        datepick.cpp

--- a/samples/widgets/src/datepicker.rs
+++ b/samples/widgets/src/datepicker.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.0-or-later WITH WxWindows-exception-3.1
+//
 // wxWidgets Sample (partially/incompletely) ported in Rust.
 // Ported by:   KENZ<KENZ.gelsoft@gmail.com>
 // Original C++ Version's Copyright is:
@@ -8,7 +10,6 @@
 // Author:      Dimitri Schoolwerth, Vadim Zeitlin
 // Created:     27 Sep 2003
 // Copyright:   (c) 2003 wxWindows team
-// Licence:     wxWindows licence
 /////////////////////////////////////////////////////////////////////////////
 
 use crate::WidgetsPage;

--- a/samples/widgets/src/datepicker.rs
+++ b/samples/widgets/src/datepicker.rs
@@ -1,3 +1,13 @@
+/////////////////////////////////////////////////////////////////////////////
+// Program:     wxWidgets Widgets Sample
+// Name:        datepick.cpp
+// Purpose:     Part of the widgets sample showing date picker
+// Author:      Dimitri Schoolwerth, Vadim Zeitlin
+// Created:     27 Sep 2003
+// Copyright:   (c) 2003 wxWindows team
+// Licence:     wxWindows licence
+/////////////////////////////////////////////////////////////////////////////
+
 use crate::WidgetsPage;
 use std::cell::RefCell;
 use std::os::raw::{c_int, c_long};

--- a/samples/widgets/src/dirctrl.rs
+++ b/samples/widgets/src/dirctrl.rs
@@ -1,3 +1,6 @@
+// wxWidgets Sample (partially/incompletely) ported in Rust.
+// Ported by:   KENZ<KENZ.gelsoft@gmail.com>
+// Original C++ Version's Copyright is:
 /////////////////////////////////////////////////////////////////////////////
 // Program:     wxWidgets Widgets Sample
 // Name:        dirctrl.cpp

--- a/samples/widgets/src/dirctrl.rs
+++ b/samples/widgets/src/dirctrl.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.0-or-later WITH WxWindows-exception-3.1
+//
 // wxWidgets Sample (partially/incompletely) ported in Rust.
 // Ported by:   KENZ<KENZ.gelsoft@gmail.com>
 // Original C++ Version's Copyright is:
@@ -8,7 +10,6 @@
 // Author:      Wlodzimierz 'ABX' Skiba
 // Created:     4 Oct 2006
 // Copyright:   (c) 2006 wxWindows team
-// Licence:     wxWindows licence
 /////////////////////////////////////////////////////////////////////////////
 
 use crate::WidgetsPage;

--- a/samples/widgets/src/dirctrl.rs
+++ b/samples/widgets/src/dirctrl.rs
@@ -1,3 +1,13 @@
+/////////////////////////////////////////////////////////////////////////////
+// Program:     wxWidgets Widgets Sample
+// Name:        dirctrl.cpp
+// Purpose:     Part of the widgets sample showing wxGenericDirCtrl
+// Author:      Wlodzimierz 'ABX' Skiba
+// Created:     4 Oct 2006
+// Copyright:   (c) 2006 wxWindows team
+// Licence:     wxWindows licence
+/////////////////////////////////////////////////////////////////////////////
+
 use crate::WidgetsPage;
 use std::cell::RefCell;
 use std::os::raw::{c_int, c_long};

--- a/samples/widgets/src/dirpicker.rs
+++ b/samples/widgets/src/dirpicker.rs
@@ -1,3 +1,13 @@
+/////////////////////////////////////////////////////////////////////////////
+// Program:     wxWidgets Widgets Sample
+// Name:        dirpicker.cpp
+// Purpose:     Shows wxDirPickerCtrl
+// Author:      Francesco Montorsi
+// Created:     20/6/2006
+// Copyright:   (c) 2006 Francesco Montorsi
+// Licence:     wxWindows licence
+/////////////////////////////////////////////////////////////////////////////
+
 use crate::WidgetsPage;
 use std::cell::RefCell;
 use std::os::raw::{c_int, c_long};

--- a/samples/widgets/src/dirpicker.rs
+++ b/samples/widgets/src/dirpicker.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.0-or-later WITH WxWindows-exception-3.1
+//
 // wxWidgets Sample (partially/incompletely) ported in Rust.
 // Ported by:   KENZ<KENZ.gelsoft@gmail.com>
 // Original C++ Version's Copyright is:
@@ -8,7 +10,6 @@
 // Author:      Francesco Montorsi
 // Created:     20/6/2006
 // Copyright:   (c) 2006 Francesco Montorsi
-// Licence:     wxWindows licence
 /////////////////////////////////////////////////////////////////////////////
 
 use crate::WidgetsPage;

--- a/samples/widgets/src/dirpicker.rs
+++ b/samples/widgets/src/dirpicker.rs
@@ -1,3 +1,6 @@
+// wxWidgets Sample (partially/incompletely) ported in Rust.
+// Ported by:   KENZ<KENZ.gelsoft@gmail.com>
+// Original C++ Version's Copyright is:
 /////////////////////////////////////////////////////////////////////////////
 // Program:     wxWidgets Widgets Sample
 // Name:        dirpicker.cpp

--- a/samples/widgets/src/editlbox.rs
+++ b/samples/widgets/src/editlbox.rs
@@ -1,3 +1,6 @@
+// wxWidgets Sample (partially/incompletely) ported in Rust.
+// Ported by:   KENZ<KENZ.gelsoft@gmail.com>
+// Original C++ Version's Copyright is:
 /////////////////////////////////////////////////////////////////////////////
 // Program:     wxWidgets Widgets Sample
 // Name:        editlbox.cpp

--- a/samples/widgets/src/editlbox.rs
+++ b/samples/widgets/src/editlbox.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.0-or-later WITH WxWindows-exception-3.1
+//
 // wxWidgets Sample (partially/incompletely) ported in Rust.
 // Ported by:   KENZ<KENZ.gelsoft@gmail.com>
 // Original C++ Version's Copyright is:
@@ -8,7 +10,6 @@
 // Author:      Francesco Montorsi
 // Created:     8/2/2009
 // Copyright:   (c) 2009 Francesco Montorsi
-// Licence:     wxWindows licence
 /////////////////////////////////////////////////////////////////////////////
 
 use crate::WidgetsPage;

--- a/samples/widgets/src/editlbox.rs
+++ b/samples/widgets/src/editlbox.rs
@@ -1,3 +1,13 @@
+/////////////////////////////////////////////////////////////////////////////
+// Program:     wxWidgets Widgets Sample
+// Name:        editlbox.cpp
+// Purpose:     Part of the widgets sample showing wxEditableListbox
+// Author:      Francesco Montorsi
+// Created:     8/2/2009
+// Copyright:   (c) 2009 Francesco Montorsi
+// Licence:     wxWindows licence
+/////////////////////////////////////////////////////////////////////////////
+
 use crate::WidgetsPage;
 use std::cell::RefCell;
 use std::os::raw::{c_int, c_long};

--- a/samples/widgets/src/filectrl.rs
+++ b/samples/widgets/src/filectrl.rs
@@ -1,3 +1,13 @@
+/////////////////////////////////////////////////////////////////////////////
+// Program:     wxWidgets Widgets Sample
+// Name:        filectrl.cpp
+// Purpose:     Part of the widgets sample showing wxFileCtrl
+// Author:      Diaa M. Sami
+// Created:     28 Jul 2007
+// Copyright:   (c) 2007 Diaa M. Sami
+// Licence:     wxWindows licence
+/////////////////////////////////////////////////////////////////////////////
+
 use crate::WidgetsPage;
 use std::cell::RefCell;
 use std::os::raw::{c_int, c_long};

--- a/samples/widgets/src/filectrl.rs
+++ b/samples/widgets/src/filectrl.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.0-or-later WITH WxWindows-exception-3.1
+//
 // wxWidgets Sample (partially/incompletely) ported in Rust.
 // Ported by:   KENZ<KENZ.gelsoft@gmail.com>
 // Original C++ Version's Copyright is:
@@ -8,7 +10,6 @@
 // Author:      Diaa M. Sami
 // Created:     28 Jul 2007
 // Copyright:   (c) 2007 Diaa M. Sami
-// Licence:     wxWindows licence
 /////////////////////////////////////////////////////////////////////////////
 
 use crate::WidgetsPage;

--- a/samples/widgets/src/filectrl.rs
+++ b/samples/widgets/src/filectrl.rs
@@ -1,3 +1,6 @@
+// wxWidgets Sample (partially/incompletely) ported in Rust.
+// Ported by:   KENZ<KENZ.gelsoft@gmail.com>
+// Original C++ Version's Copyright is:
 /////////////////////////////////////////////////////////////////////////////
 // Program:     wxWidgets Widgets Sample
 // Name:        filectrl.cpp

--- a/samples/widgets/src/filepicker.rs
+++ b/samples/widgets/src/filepicker.rs
@@ -1,3 +1,13 @@
+/////////////////////////////////////////////////////////////////////////////
+// Program:     wxWidgets Widgets Sample
+// Name:        filepicker.cpp
+// Purpose:     Part of the widgets sample showing wx*PickerCtrl
+// Author:      Francesco Montorsi
+// Created:     20/6/2006
+// Copyright:   (c) 2006 Francesco Montorsi
+// Licence:     wxWindows licence
+/////////////////////////////////////////////////////////////////////////////
+
 use crate::WidgetsPage;
 use std::cell::RefCell;
 use std::os::raw::{c_int, c_long};

--- a/samples/widgets/src/filepicker.rs
+++ b/samples/widgets/src/filepicker.rs
@@ -1,3 +1,6 @@
+// wxWidgets Sample (partially/incompletely) ported in Rust.
+// Ported by:   KENZ<KENZ.gelsoft@gmail.com>
+// Original C++ Version's Copyright is:
 /////////////////////////////////////////////////////////////////////////////
 // Program:     wxWidgets Widgets Sample
 // Name:        filepicker.cpp

--- a/samples/widgets/src/filepicker.rs
+++ b/samples/widgets/src/filepicker.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.0-or-later WITH WxWindows-exception-3.1
+//
 // wxWidgets Sample (partially/incompletely) ported in Rust.
 // Ported by:   KENZ<KENZ.gelsoft@gmail.com>
 // Original C++ Version's Copyright is:
@@ -8,7 +10,6 @@
 // Author:      Francesco Montorsi
 // Created:     20/6/2006
 // Copyright:   (c) 2006 Francesco Montorsi
-// Licence:     wxWindows licence
 /////////////////////////////////////////////////////////////////////////////
 
 use crate::WidgetsPage;

--- a/samples/widgets/src/fontpicker.rs
+++ b/samples/widgets/src/fontpicker.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.0-or-later WITH WxWindows-exception-3.1
+//
 // wxWidgets Sample (partially/incompletely) ported in Rust.
 // Ported by:   KENZ<KENZ.gelsoft@gmail.com>
 // Original C++ Version's Copyright is:
@@ -8,7 +10,6 @@
 // Author:      Francesco Montorsi
 // Created:     20/6/2006
 // Copyright:   (c) 2006 Francesco Montorsi
-// Licence:     wxWindows licence
 /////////////////////////////////////////////////////////////////////////////
 
 use crate::WidgetsPage;

--- a/samples/widgets/src/fontpicker.rs
+++ b/samples/widgets/src/fontpicker.rs
@@ -1,3 +1,13 @@
+/////////////////////////////////////////////////////////////////////////////
+// Program:     wxWidgets Widgets Sample
+// Name:        fontpicker.cpp
+// Purpose:     Shows wxFontPickerCtrl
+// Author:      Francesco Montorsi
+// Created:     20/6/2006
+// Copyright:   (c) 2006 Francesco Montorsi
+// Licence:     wxWindows licence
+/////////////////////////////////////////////////////////////////////////////
+
 use crate::WidgetsPage;
 use std::cell::RefCell;
 use std::os::raw::{c_int, c_long};

--- a/samples/widgets/src/fontpicker.rs
+++ b/samples/widgets/src/fontpicker.rs
@@ -1,3 +1,6 @@
+// wxWidgets Sample (partially/incompletely) ported in Rust.
+// Ported by:   KENZ<KENZ.gelsoft@gmail.com>
+// Original C++ Version's Copyright is:
 /////////////////////////////////////////////////////////////////////////////
 // Program:     wxWidgets Widgets Sample
 // Name:        fontpicker.cpp

--- a/samples/widgets/src/gauge.rs
+++ b/samples/widgets/src/gauge.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.0-or-later WITH WxWindows-exception-3.1
+//
 // wxWidgets Sample (partially/incompletely) ported in Rust.
 // Ported by:   KENZ<KENZ.gelsoft@gmail.com>
 // Original C++ Version's Copyright is:
@@ -8,7 +10,6 @@
 // Author:      Vadim Zeitlin
 // Created:     27.03.01
 // Copyright:   (c) 2001 Vadim Zeitlin
-// Licence:     wxWindows licence
 /////////////////////////////////////////////////////////////////////////////
 
 use crate::WidgetsPage;

--- a/samples/widgets/src/gauge.rs
+++ b/samples/widgets/src/gauge.rs
@@ -1,3 +1,13 @@
+/////////////////////////////////////////////////////////////////////////////
+// Program:     wxWidgets Widgets Sample
+// Name:        gauge.cpp
+// Purpose:     Part of the widgets sample showing wxGauge
+// Author:      Vadim Zeitlin
+// Created:     27.03.01
+// Copyright:   (c) 2001 Vadim Zeitlin
+// Licence:     wxWindows licence
+/////////////////////////////////////////////////////////////////////////////
+
 use crate::WidgetsPage;
 use std::cell::RefCell;
 use std::os::raw::{c_int, c_long};

--- a/samples/widgets/src/gauge.rs
+++ b/samples/widgets/src/gauge.rs
@@ -1,3 +1,6 @@
+// wxWidgets Sample (partially/incompletely) ported in Rust.
+// Ported by:   KENZ<KENZ.gelsoft@gmail.com>
+// Original C++ Version's Copyright is:
 /////////////////////////////////////////////////////////////////////////////
 // Program:     wxWidgets Widgets Sample
 // Name:        gauge.cpp

--- a/samples/widgets/src/headerctrl.rs
+++ b/samples/widgets/src/headerctrl.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.0-or-later WITH WxWindows-exception-3.1
+//
 // wxWidgets Sample (partially/incompletely) ported in Rust.
 // Ported by:   KENZ<KENZ.gelsoft@gmail.com>
 // Original C++ Version's Copyright is:
@@ -8,7 +10,6 @@
 // Author:      Vadim Zeitlin
 // Created:     2016-04-17
 // Copyright:   (c) 2016 wxWindows team
-// Licence:     wxWindows licence
 /////////////////////////////////////////////////////////////////////////////
 
 use crate::WidgetsPage;

--- a/samples/widgets/src/headerctrl.rs
+++ b/samples/widgets/src/headerctrl.rs
@@ -1,3 +1,13 @@
+/////////////////////////////////////////////////////////////////////////////
+// Program:     wxWidgets Widgets Sample
+// Name:        headerctrl.cpp
+// Purpose:     Part of the widgets sample showing wxHeaderCtrl
+// Author:      Vadim Zeitlin
+// Created:     2016-04-17
+// Copyright:   (c) 2016 wxWindows team
+// Licence:     wxWindows licence
+/////////////////////////////////////////////////////////////////////////////
+
 use crate::WidgetsPage;
 use std::cell::RefCell;
 use std::os::raw::{c_int, c_long};

--- a/samples/widgets/src/headerctrl.rs
+++ b/samples/widgets/src/headerctrl.rs
@@ -1,3 +1,6 @@
+// wxWidgets Sample (partially/incompletely) ported in Rust.
+// Ported by:   KENZ<KENZ.gelsoft@gmail.com>
+// Original C++ Version's Copyright is:
 /////////////////////////////////////////////////////////////////////////////
 // Program:     wxWidgets Widgets Sample
 // Name:        headerctrl.cpp

--- a/samples/widgets/src/hyperlink.rs
+++ b/samples/widgets/src/hyperlink.rs
@@ -1,3 +1,6 @@
+// wxWidgets Sample (partially/incompletely) ported in Rust.
+// Ported by:   KENZ<KENZ.gelsoft@gmail.com>
+// Original C++ Version's Copyright is:
 /////////////////////////////////////////////////////////////////////////////
 // Program:     wxWidgets Widgets Sample
 // Name:        hyperlnk.cpp

--- a/samples/widgets/src/hyperlink.rs
+++ b/samples/widgets/src/hyperlink.rs
@@ -1,3 +1,13 @@
+/////////////////////////////////////////////////////////////////////////////
+// Program:     wxWidgets Widgets Sample
+// Name:        hyperlnk.cpp
+// Purpose:     Part of the widgets sample showing wxHyperlinkCtrl
+// Author:      Dimitri Schoolwerth, Vadim Zeitlin
+// Created:     27 Sep 2003
+// Copyright:   (c) 2003 wxWindows team
+// Licence:     wxWindows licence
+/////////////////////////////////////////////////////////////////////////////
+
 use crate::WidgetsPage;
 use std::cell::RefCell;
 use std::os::raw::{c_int, c_long};

--- a/samples/widgets/src/hyperlink.rs
+++ b/samples/widgets/src/hyperlink.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.0-or-later WITH WxWindows-exception-3.1
+//
 // wxWidgets Sample (partially/incompletely) ported in Rust.
 // Ported by:   KENZ<KENZ.gelsoft@gmail.com>
 // Original C++ Version's Copyright is:
@@ -8,7 +10,6 @@
 // Author:      Dimitri Schoolwerth, Vadim Zeitlin
 // Created:     27 Sep 2003
 // Copyright:   (c) 2003 wxWindows team
-// Licence:     wxWindows licence
 /////////////////////////////////////////////////////////////////////////////
 
 use crate::WidgetsPage;

--- a/samples/widgets/src/listbox.rs
+++ b/samples/widgets/src/listbox.rs
@@ -1,3 +1,13 @@
+/////////////////////////////////////////////////////////////////////////////
+// Program:     wxWidgets Widgets Sample
+// Name:        listbox.cpp
+// Purpose:     Part of the widgets sample showing wxListbox
+// Author:      Vadim Zeitlin
+// Created:     27.03.01
+// Copyright:   (c) 2001 Vadim Zeitlin
+// Licence:     wxWindows licence
+/////////////////////////////////////////////////////////////////////////////
+
 use crate::WidgetsPage;
 use std::cell::RefCell;
 use std::os::raw::{c_int, c_long};

--- a/samples/widgets/src/listbox.rs
+++ b/samples/widgets/src/listbox.rs
@@ -1,3 +1,6 @@
+// wxWidgets Sample (partially/incompletely) ported in Rust.
+// Ported by:   KENZ<KENZ.gelsoft@gmail.com>
+// Original C++ Version's Copyright is:
 /////////////////////////////////////////////////////////////////////////////
 // Program:     wxWidgets Widgets Sample
 // Name:        listbox.cpp

--- a/samples/widgets/src/listbox.rs
+++ b/samples/widgets/src/listbox.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.0-or-later WITH WxWindows-exception-3.1
+//
 // wxWidgets Sample (partially/incompletely) ported in Rust.
 // Ported by:   KENZ<KENZ.gelsoft@gmail.com>
 // Original C++ Version's Copyright is:
@@ -8,7 +10,6 @@
 // Author:      Vadim Zeitlin
 // Created:     27.03.01
 // Copyright:   (c) 2001 Vadim Zeitlin
-// Licence:     wxWindows licence
 /////////////////////////////////////////////////////////////////////////////
 
 use crate::WidgetsPage;

--- a/samples/widgets/src/main.rs
+++ b/samples/widgets/src/main.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.0-or-later WITH WxWindows-exception-3.1
+//
 // wxWidgets Sample (partially/incompletely) ported in Rust.
 // Ported by:   KENZ<KENZ.gelsoft@gmail.com>
 // Original C++ Version's Copyright is:
@@ -8,7 +10,6 @@
 // Author:      Vadim Zeitlin
 // Created:     27.03.01
 // Copyright:   (c) 2001 Vadim Zeitlin
-// Licence:     wxWindows licence
 /////////////////////////////////////////////////////////////////////////////
 
 #![windows_subsystem = "windows"]

--- a/samples/widgets/src/main.rs
+++ b/samples/widgets/src/main.rs
@@ -1,3 +1,13 @@
+/////////////////////////////////////////////////////////////////////////////
+// Program:     wxWidgets Widgets Sample
+// Name:        samples/widgets/widgets.cpp
+// Purpose:     Sample showing most of the simple wxWidgets widgets
+// Author:      Vadim Zeitlin
+// Created:     27.03.01
+// Copyright:   (c) 2001 Vadim Zeitlin
+// Licence:     wxWindows licence
+/////////////////////////////////////////////////////////////////////////////
+
 #![windows_subsystem = "windows"]
 
 use std::os::raw::c_int;

--- a/samples/widgets/src/main.rs
+++ b/samples/widgets/src/main.rs
@@ -1,3 +1,6 @@
+// wxWidgets Sample (partially/incompletely) ported in Rust.
+// Ported by:   KENZ<KENZ.gelsoft@gmail.com>
+// Original C++ Version's Copyright is:
 /////////////////////////////////////////////////////////////////////////////
 // Program:     wxWidgets Widgets Sample
 // Name:        samples/widgets/widgets.cpp

--- a/samples/widgets/src/searchctrl.rs
+++ b/samples/widgets/src/searchctrl.rs
@@ -1,3 +1,13 @@
+/////////////////////////////////////////////////////////////////////////////
+// Program:     wxWidgets Widgets Sample
+// Name:        searchctrl.cpp
+// Purpose:     Shows wxSearchCtrl
+// Author:      Robin Dunn
+// Created:     9-Dec-2006
+// Copyright:   (c) 2006
+// Licence:     wxWindows licence
+/////////////////////////////////////////////////////////////////////////////
+
 use crate::WidgetsPage;
 use std::cell::RefCell;
 use std::os::raw::c_int;

--- a/samples/widgets/src/searchctrl.rs
+++ b/samples/widgets/src/searchctrl.rs
@@ -1,3 +1,6 @@
+// wxWidgets Sample (partially/incompletely) ported in Rust.
+// Ported by:   KENZ<KENZ.gelsoft@gmail.com>
+// Original C++ Version's Copyright is:
 /////////////////////////////////////////////////////////////////////////////
 // Program:     wxWidgets Widgets Sample
 // Name:        searchctrl.cpp

--- a/samples/widgets/src/searchctrl.rs
+++ b/samples/widgets/src/searchctrl.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.0-or-later WITH WxWindows-exception-3.1
+//
 // wxWidgets Sample (partially/incompletely) ported in Rust.
 // Ported by:   KENZ<KENZ.gelsoft@gmail.com>
 // Original C++ Version's Copyright is:
@@ -8,7 +10,6 @@
 // Author:      Robin Dunn
 // Created:     9-Dec-2006
 // Copyright:   (c) 2006
-// Licence:     wxWindows licence
 /////////////////////////////////////////////////////////////////////////////
 
 use crate::WidgetsPage;

--- a/samples/widgets/src/slider.rs
+++ b/samples/widgets/src/slider.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.0-or-later WITH WxWindows-exception-3.1
+//
 // wxWidgets Sample (partially/incompletely) ported in Rust.
 // Ported by:   KENZ<KENZ.gelsoft@gmail.com>
 // Original C++ Version's Copyright is:
@@ -8,7 +10,6 @@
 // Author:      Vadim Zeitlin
 // Created:     16.04.01
 // Copyright:   (c) 2001 Vadim Zeitlin
-// Licence:     wxWindows licence
 /////////////////////////////////////////////////////////////////////////////
 
 use crate::WidgetsPage;

--- a/samples/widgets/src/slider.rs
+++ b/samples/widgets/src/slider.rs
@@ -1,3 +1,6 @@
+// wxWidgets Sample (partially/incompletely) ported in Rust.
+// Ported by:   KENZ<KENZ.gelsoft@gmail.com>
+// Original C++ Version's Copyright is:
 /////////////////////////////////////////////////////////////////////////////
 // Program:     wxWidgets Widgets Sample
 // Name:        slider.cpp

--- a/samples/widgets/src/slider.rs
+++ b/samples/widgets/src/slider.rs
@@ -1,3 +1,13 @@
+/////////////////////////////////////////////////////////////////////////////
+// Program:     wxWidgets Widgets Sample
+// Name:        slider.cpp
+// Purpose:     Part of the widgets sample showing wxSlider
+// Author:      Vadim Zeitlin
+// Created:     16.04.01
+// Copyright:   (c) 2001 Vadim Zeitlin
+// Licence:     wxWindows licence
+/////////////////////////////////////////////////////////////////////////////
+
 use crate::WidgetsPage;
 use std::cell::RefCell;
 use std::os::raw::{c_int, c_long};

--- a/samples/widgets/src/spinbutton.rs
+++ b/samples/widgets/src/spinbutton.rs
@@ -1,3 +1,6 @@
+// wxWidgets Sample (partially/incompletely) ported in Rust.
+// Ported by:   KENZ<KENZ.gelsoft@gmail.com>
+// Original C++ Version's Copyright is:
 /////////////////////////////////////////////////////////////////////////////
 // Program:     wxWidgets Widgets Sample
 // Name:        spinbtn.cpp

--- a/samples/widgets/src/spinbutton.rs
+++ b/samples/widgets/src/spinbutton.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.0-or-later WITH WxWindows-exception-3.1
+//
 // wxWidgets Sample (partially/incompletely) ported in Rust.
 // Ported by:   KENZ<KENZ.gelsoft@gmail.com>
 // Original C++ Version's Copyright is:
@@ -8,7 +10,6 @@
 // Author:      Vadim Zeitlin
 // Created:     16.04.01
 // Copyright:   (c) 2001 Vadim Zeitlin
-// Licence:     wxWindows licence
 /////////////////////////////////////////////////////////////////////////////
 
 use crate::WidgetsPage;

--- a/samples/widgets/src/spinbutton.rs
+++ b/samples/widgets/src/spinbutton.rs
@@ -1,3 +1,13 @@
+/////////////////////////////////////////////////////////////////////////////
+// Program:     wxWidgets Widgets Sample
+// Name:        spinbtn.cpp
+// Purpose:     Part of the widgets sample showing wxSpinButton
+// Author:      Vadim Zeitlin
+// Created:     16.04.01
+// Copyright:   (c) 2001 Vadim Zeitlin
+// Licence:     wxWindows licence
+/////////////////////////////////////////////////////////////////////////////
+
 use crate::WidgetsPage;
 use std::cell::RefCell;
 use std::os::raw::{c_int, c_long};

--- a/samples/widgets/src/timepicker.rs
+++ b/samples/widgets/src/timepicker.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.0-or-later WITH WxWindows-exception-3.1
+//
 // wxWidgets Sample (partially/incompletely) ported in Rust.
 // Ported by:   KENZ<KENZ.gelsoft@gmail.com>
 // Original C++ Version's Copyright is:
@@ -8,7 +10,6 @@
 // Author:      Vadim Zeitlin
 // Created:     2011-12-20
 // Copyright:   (c) 2011 wxWindows team
-// Licence:     wxWindows licence
 /////////////////////////////////////////////////////////////////////////////
 
 extern crate regex;

--- a/samples/widgets/src/timepicker.rs
+++ b/samples/widgets/src/timepicker.rs
@@ -1,3 +1,13 @@
+/////////////////////////////////////////////////////////////////////////////
+// Program:     wxWidgets Widgets Sample
+// Name:        timepick.cpp
+// Purpose:     Part of the widgets sample showing time picker
+// Author:      Vadim Zeitlin
+// Created:     2011-12-20
+// Copyright:   (c) 2011 wxWindows team
+// Licence:     wxWindows licence
+/////////////////////////////////////////////////////////////////////////////
+
 extern crate regex;
 
 use crate::WidgetsPage;

--- a/samples/widgets/src/timepicker.rs
+++ b/samples/widgets/src/timepicker.rs
@@ -1,3 +1,6 @@
+// wxWidgets Sample (partially/incompletely) ported in Rust.
+// Ported by:   KENZ<KENZ.gelsoft@gmail.com>
+// Original C++ Version's Copyright is:
 /////////////////////////////////////////////////////////////////////////////
 // Program:     wxWidgets Widgets Sample
 // Name:        timepick.cpp

--- a/samples/widgets/src/toggle.rs
+++ b/samples/widgets/src/toggle.rs
@@ -1,3 +1,13 @@
+/////////////////////////////////////////////////////////////////////////////
+// Program:     wxWidgets Widgets Sample
+// Name:        toggle.cpp
+// Purpose:     Part of the widgets sample showing toggle control
+// Author:      Dimitri Schoolwerth, Vadim Zeitlin
+// Created:     27 Sep 2003
+// Copyright:   (c) 2006 Wlodzmierz Skiba
+// Licence:     wxWindows licence
+/////////////////////////////////////////////////////////////////////////////
+
 use crate::WidgetsPage;
 use std::cell::RefCell;
 use std::os::raw::{c_int, c_long};

--- a/samples/widgets/src/toggle.rs
+++ b/samples/widgets/src/toggle.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.0-or-later WITH WxWindows-exception-3.1
+//
 // wxWidgets Sample (partially/incompletely) ported in Rust.
 // Ported by:   KENZ<KENZ.gelsoft@gmail.com>
 // Original C++ Version's Copyright is:
@@ -8,7 +10,6 @@
 // Author:      Dimitri Schoolwerth, Vadim Zeitlin
 // Created:     27 Sep 2003
 // Copyright:   (c) 2006 Wlodzmierz Skiba
-// Licence:     wxWindows licence
 /////////////////////////////////////////////////////////////////////////////
 
 use crate::WidgetsPage;

--- a/samples/widgets/src/toggle.rs
+++ b/samples/widgets/src/toggle.rs
@@ -1,3 +1,6 @@
+// wxWidgets Sample (partially/incompletely) ported in Rust.
+// Ported by:   KENZ<KENZ.gelsoft@gmail.com>
+// Original C++ Version's Copyright is:
 /////////////////////////////////////////////////////////////////////////////
 // Program:     wxWidgets Widgets Sample
 // Name:        toggle.cpp

--- a/samples/wrapsizer/src/main.rs
+++ b/samples/wrapsizer/src/main.rs
@@ -1,3 +1,12 @@
+/////////////////////////////////////////////////////////////////////////////
+// Name:        wrapsizer.cpp
+// Purpose:     wxWidgets sample demonstrating wxWrapSizer use
+// Author:      Arne Steinarson
+// Created:     21.01.2008
+// Copyright:   (c) Arne Steinarson
+// Licence:     wxWindows licence
+/////////////////////////////////////////////////////////////////////////////
+
 #![windows_subsystem = "windows"]
 
 use wx;

--- a/samples/wrapsizer/src/main.rs
+++ b/samples/wrapsizer/src/main.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.0-or-later WITH WxWindows-exception-3.1
+//
 // wxWidgets Sample (partially/incompletely) ported in Rust.
 // Ported by:   KENZ<KENZ.gelsoft@gmail.com>
 // Original C++ Version's Copyright is:
@@ -7,7 +9,6 @@
 // Author:      Arne Steinarson
 // Created:     21.01.2008
 // Copyright:   (c) Arne Steinarson
-// Licence:     wxWindows licence
 /////////////////////////////////////////////////////////////////////////////
 
 #![windows_subsystem = "windows"]

--- a/samples/wrapsizer/src/main.rs
+++ b/samples/wrapsizer/src/main.rs
@@ -1,3 +1,6 @@
+// wxWidgets Sample (partially/incompletely) ported in Rust.
+// Ported by:   KENZ<KENZ.gelsoft@gmail.com>
+// Original C++ Version's Copyright is:
 /////////////////////////////////////////////////////////////////////////////
 // Name:        wrapsizer.cpp
 // Purpose:     wxWidgets sample demonstrating wxWrapSizer use


### PR DESCRIPTION
part of #37

These files are effectively code-to-code direct port, so should have been licensed under the original license.