### PR TITLE
Changes before publish to crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,8 +21,8 @@ checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
 name = "hello"
 version = "0.1.0"
 dependencies = [
- "wx",
- "wx-base",
+ "wxrust",
+ "wxrust-base",
 ]
 
 [[package]]
@@ -35,8 +35,8 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 name = "minimal"
 version = "0.1.0"
 dependencies = [
- "wx",
- "wx-base",
+ "wxrust",
+ "wxrust-base",
 ]
 
 [[package]]
@@ -61,39 +61,16 @@ name = "widgets"
 version = "0.1.0"
 dependencies = [
  "regex",
- "wx",
- "wx-base",
+ "wxrust",
+ "wxrust-base",
 ]
 
 [[package]]
 name = "wrapsizer"
 version = "0.1.0"
 dependencies = [
- "wx",
- "wx-base",
-]
-
-[[package]]
-name = "wx"
-version = "0.1.0"
-dependencies = [
- "cc",
- "wx-base",
- "wx-universal-apple-darwin",
- "wx-x86_64-pc-windows-gnu",
- "wx-x86_64-pc-windows-msvc",
- "wxrust-config",
-]
-
-[[package]]
-name = "wx-base"
-version = "0.1.0"
-dependencies = [
- "cc",
- "wx-universal-apple-darwin",
- "wx-x86_64-pc-windows-gnu",
- "wx-x86_64-pc-windows-msvc",
- "wxrust-config",
+ "wxrust",
+ "wxrust-base",
 ]
 
 [[package]]
@@ -110,6 +87,29 @@ source = "git+https://github.com/ancwrd1/wx-x86_64-pc-windows-gnu#b41af996f76669
 name = "wx-x86_64-pc-windows-msvc"
 version = "3.2.0"
 source = "git+https://github.com/kenz-gelsoft/wx-x86_64-pc-windows-msvc#ed36771152a5c03212bce34b17d95629e1f8f8a9"
+
+[[package]]
+name = "wxrust"
+version = "0.0.1"
+dependencies = [
+ "cc",
+ "wx-universal-apple-darwin",
+ "wx-x86_64-pc-windows-gnu",
+ "wx-x86_64-pc-windows-msvc",
+ "wxrust-base",
+ "wxrust-config",
+]
+
+[[package]]
+name = "wxrust-base"
+version = "0.0.1"
+dependencies = [
+ "cc",
+ "wx-universal-apple-darwin",
+ "wx-x86_64-pc-windows-gnu",
+ "wx-x86_64-pc-windows-msvc",
+ "wxrust-config",
+]
 
 [[package]]
 name = "wxrust-config"

--- a/samples/hello/Cargo.toml
+++ b/samples/hello/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-wx-base = { path = "../../wx-base" }
-wx = { path = "../../wx-core" }
+wx-base = { path = "../../wx-base", package="wxrust-base" }
+wx = { path = "../../wx-core", package="wxrust" }

--- a/samples/minimal/Cargo.toml
+++ b/samples/minimal/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-wx-base = { path = "../../wx-base" }
-wx = { path = "../../wx-core" }
+wx-base = { path = "../../wx-base", package="wxrust-base" }
+wx = { path = "../../wx-core", package="wxrust" }

--- a/samples/widgets/Cargo.toml
+++ b/samples/widgets/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2021"
 
 [dependencies]
 regex = "1.5"
-wx-base = { path = "../../wx-base" }
-wx = { path = "../../wx-core" }
+wx-base = { path = "../../wx-base", package="wxrust-base" }
+wx = { path = "../../wx-core", package="wxrust" }

--- a/samples/wrapsizer/Cargo.toml
+++ b/samples/wrapsizer/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-wx-base = { path = "../../wx-base" }
-wx = { path = "../../wx-core" }
+wx-base = { path = "../../wx-base", package="wxrust-base" }
+wx = { path = "../../wx-core", package="wxrust" }

--- a/wx-base/Cargo.toml
+++ b/wx-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "wx-base"
-version = "0.1.0"
+name = "wxrust-base"
+version = "0.0.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/wx-base/README.md
+++ b/wx-base/README.md
@@ -1,6 +1,6 @@
 # `wx-base`
 
-Thie crate is a binding to [the wxBase library of the wxWidgets toolkit](https://docs.wxwidgets.org/3.2/page_libs.html#page_libs_wxbase).
+This crate is a binding to [the wxBase library of the wxWidgets toolkit](https://docs.wxwidgets.org/3.2/page_libs.html#page_libs_wxbase).
 
 This crate supports only small part of the library which is used by the `wx`(`wxrust`) crate.
 

--- a/wx-base/README.md
+++ b/wx-base/README.md
@@ -1,0 +1,9 @@
+# `wx-base`
+
+Thie crate is a binding to [the wxBase library of the wxWidgets toolkit](https://docs.wxwidgets.org/3.2/page_libs.html#page_libs_wxbase).
+
+This crate supports only small part of the library which is used by the `wx`(`wxrust`) crate.
+
+Original C++ library supports basic non-GUI cross-platform programming, but this crate doesn't bacause there is many option already for that purpose in the Rust ecosystem.
+
+Members of this crate are re-exported by the `wx`(`wxrust`) crate, so you don't need specify dependency to this crate.

--- a/wx-base/src/lib.rs
+++ b/wx-base/src/lib.rs
@@ -1,3 +1,5 @@
+#![doc = include_str!("../README.md")]
+
 use std::marker::PhantomData;
 use std::mem;
 use std::os::raw::{c_char, c_int, c_void};

--- a/wx-core/Cargo.toml
+++ b/wx-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "wx"
-version = "0.1.0"
+name = "wxrust"
+version = "0.0.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -14,7 +14,7 @@ vendored = [
 ]
 
 [dependencies]
-wx-base = { path = "../wx-base" }
+wx-base = { path = "../wx-base", package="wxrust-base" }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 wx-universal-apple-darwin = { git = "https://github.com/ancwrd1/wx-universal-apple-darwin", optional = true }

--- a/wx-core/README.md
+++ b/wx-core/README.md
@@ -1,8 +1,8 @@
 # `wx`
 
-Thie crate is a binding to [the wxCore library of the wxWidgets toolkit](https://docs.wxwidgets.org/3.2/page_libs.html#page_libs_wxcore).
+This crate is a binding to [the wxCore library of the wxWidgets toolkit](https://docs.wxwidgets.org/3.2/page_libs.html#page_libs_wxcore).
 
-This crate is `wxrust` not `wx` in crates.io as the name already in use.
+This crate is `wxrust` not `wx` in crates.io as the name is already in use.
 
 It is recommended to specify dependency to this library [with renaming](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#renaming-dependencies-in-cargotoml) like this:
 

--- a/wx-core/README.md
+++ b/wx-core/README.md
@@ -1,0 +1,12 @@
+# `wx`
+
+Thie crate is a binding to [the wxCore library of the wxWidgets toolkit](https://docs.wxwidgets.org/3.2/page_libs.html#page_libs_wxcore).
+
+This crate is `wxrust` not `wx` in crates.io as the name already in use.
+
+It is recommended to specify dependency to this library [with renaming](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#renaming-dependencies-in-cargotoml) like this:
+
+```TOML
+[dependencies]
+wx = { version = "0.0.*", package = "wxrust" }
+```

--- a/wx-core/src/lib.rs
+++ b/wx-core/src/lib.rs
@@ -1,3 +1,5 @@
+#![doc = include_str!("../README.md")]
+
 use std::mem;
 use std::os::raw::{c_double, c_int, c_long, c_void};
 use std::ptr;


### PR DESCRIPTION
- Change crate names to unused ones.
- Change version to express no API stability at all.
- Write basic doc per crate.

closes  #155