### PR TITLE
Changes for wxrust-config 0.0.1-alpha release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,7 +97,7 @@ dependencies = [
  "wx-x86_64-pc-windows-gnu",
  "wx-x86_64-pc-windows-msvc",
  "wxrust-base",
- "wxrust-config",
+ "wxrust-config 0.0.1-alpha",
 ]
 
 [[package]]
@@ -108,12 +108,21 @@ dependencies = [
  "wx-universal-apple-darwin",
  "wx-x86_64-pc-windows-gnu",
  "wx-x86_64-pc-windows-msvc",
- "wxrust-config",
+ "wxrust-config 0.0.1-alpha (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wxrust-config"
 version = "0.0.1-alpha"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "wxrust-config"
+version = "0.0.1-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6730ab8fe7b39e6273c0c82eed6184f860766fabe273b127fa99cd0ea5cd0da7"
 dependencies = [
  "cc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,7 +97,7 @@ dependencies = [
  "wx-x86_64-pc-windows-gnu",
  "wx-x86_64-pc-windows-msvc",
  "wxrust-base",
- "wxrust-config 0.0.1-alpha",
+ "wxrust-config 0.0.1-alpha (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ source = "git+https://github.com/kenz-gelsoft/wx-x86_64-pc-windows-msvc#ed367711
 
 [[package]]
 name = "wxrust"
-version = "0.0.1"
+version = "0.0.1-alpha"
 dependencies = [
  "cc",
  "wx-universal-apple-darwin",
@@ -102,7 +102,7 @@ dependencies = [
 
 [[package]]
 name = "wxrust-base"
-version = "0.0.1"
+version = "0.0.1-alpha"
 dependencies = [
  "cc",
  "wx-universal-apple-darwin",
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "wxrust-config"
-version = "0.1.0"
+version = "0.0.1-alpha"
 dependencies = [
  "cc",
 ]

--- a/wx-base/Cargo.toml
+++ b/wx-base/Cargo.toml
@@ -26,4 +26,4 @@ wx-x86_64-pc-windows-msvc = { git = "https://github.com/kenz-gelsoft/wx-x86_64-p
 
 [build-dependencies]
 cc = "1.0.72"
-wxrust-config = "0.0.*"
+wxrust-config = "0.0.1-alpha"

--- a/wx-base/Cargo.toml
+++ b/wx-base/Cargo.toml
@@ -2,6 +2,8 @@
 name = "wxrust-base"
 version = "0.0.1-alpha"
 edition = "2021"
+description = "Binding for the (part of) wxBase library of the wxWidgets toolkit."
+license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/wx-base/Cargo.toml
+++ b/wx-base/Cargo.toml
@@ -26,4 +26,4 @@ wx-x86_64-pc-windows-msvc = { git = "https://github.com/kenz-gelsoft/wx-x86_64-p
 
 [build-dependencies]
 cc = "1.0.72"
-wxrust-config = { path = "../wxrust-config" }
+wxrust-config = "0.0.*"

--- a/wx-base/Cargo.toml
+++ b/wx-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wxrust-base"
-version = "0.0.1"
+version = "0.0.1-alpha"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/wx-core/Cargo.toml
+++ b/wx-core/Cargo.toml
@@ -29,4 +29,4 @@ wx-x86_64-pc-windows-msvc = { git = "https://github.com/kenz-gelsoft/wx-x86_64-p
 
 [build-dependencies]
 cc = "1.0.72"
-wxrust-config = { path = "../wxrust-config" }
+wxrust-config = "0.0.*"

--- a/wx-core/Cargo.toml
+++ b/wx-core/Cargo.toml
@@ -2,6 +2,8 @@
 name = "wxrust"
 version = "0.0.1-alpha"
 edition = "2021"
+description = "Binding for the wxCore library of the wxWidgets toolkit."
+license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/wx-core/Cargo.toml
+++ b/wx-core/Cargo.toml
@@ -29,4 +29,4 @@ wx-x86_64-pc-windows-msvc = { git = "https://github.com/kenz-gelsoft/wx-x86_64-p
 
 [build-dependencies]
 cc = "1.0.72"
-wxrust-config = "0.0.*"
+wxrust-config = "0.0.1-alpha"

--- a/wx-core/Cargo.toml
+++ b/wx-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wxrust"
-version = "0.0.1"
+version = "0.0.1-alpha"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/wxrust-config/Cargo.toml
+++ b/wxrust-config/Cargo.toml
@@ -2,6 +2,8 @@
 name = "wxrust-config"
 version = "0.0.1-alpha"
 edition = "2021"
+description = "Build support crate for wxrust packages."
+license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/wxrust-config/Cargo.toml
+++ b/wxrust-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wxrust-config"
-version = "0.1.0"
+version = "0.0.1-alpha"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
- Changed version to alpha and add some metadata to publish.
- wxrust-config 0.0.1-alpha is published on this state.
- other wx-* crates are not published not yet for #162.