### PR TITLE
Simplify wxrust-config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,7 +97,7 @@ dependencies = [
  "wx-x86_64-pc-windows-gnu",
  "wx-x86_64-pc-windows-msvc",
  "wxrust-base",
- "wxrust-config 0.0.1-alpha (registry+https://github.com/rust-lang/crates.io-index)",
+ "wxrust-config",
 ]
 
 [[package]]
@@ -108,21 +108,12 @@ dependencies = [
  "wx-universal-apple-darwin",
  "wx-x86_64-pc-windows-gnu",
  "wx-x86_64-pc-windows-msvc",
- "wxrust-config 0.0.1-alpha (registry+https://github.com/rust-lang/crates.io-index)",
+ "wxrust-config",
 ]
 
 [[package]]
 name = "wxrust-config"
-version = "0.0.1-alpha"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "wxrust-config"
-version = "0.0.1-alpha"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6730ab8fe7b39e6273c0c82eed6184f860766fabe273b127fa99cd0ea5cd0da7"
+version = "0.0.1-alpha2"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,6 @@ members = [
     "wx-core",
     "wxrust-config",
 ]
+
+[patch.crates-io]
+wxrust-config = { path = "wxrust-config" }

--- a/wx-base/Cargo.toml
+++ b/wx-base/Cargo.toml
@@ -26,4 +26,4 @@ wx-x86_64-pc-windows-msvc = { git = "https://github.com/kenz-gelsoft/wx-x86_64-p
 
 [build-dependencies]
 cc = "1.0.72"
-wxrust-config = "0.0.1-alpha"
+wxrust-config = "0.0.1-alpha2"

--- a/wx-base/build.rs
+++ b/wx-base/build.rs
@@ -7,6 +7,10 @@ fn main() {
         .file("src/generated.cpp")
         .include("include")
         .flag_if_supported("-std=c++14")
+        // ignore too many warnings with wx3.0
+        .flag_if_supported("-Wno-deprecated-copy")
+        .flag_if_supported("-Wno-ignored-qualifiers")
+        .flag_if_supported("-Wno-unused-parameter")
         .compile("wx");
 
     // from `wx-config --libs`

--- a/wx-base/build.rs
+++ b/wx-base/build.rs
@@ -1,4 +1,4 @@
-use wxrust_config::{print_wx_config_libs_for_cargo, wx_config_cflags};
+use wxrust_config::{wx_config, wx_config_cflags};
 
 fn main() {
     wx_config_cflags(&mut cc::Build::new())
@@ -9,5 +9,7 @@ fn main() {
         .flag_if_supported("-std=c++14")
         .compile("wx");
 
-    print_wx_config_libs_for_cargo();
+    // from `wx-config --libs`
+    let libs = wx_config(&["--libs"]);
+    println!("cargo:rustc-flags={}", libs.join(" "));
 }

--- a/wx-base/build.rs
+++ b/wx-base/build.rs
@@ -1,7 +1,12 @@
-use wxrust_config::{wx_config, wx_config_cflags};
+use wxrust_config::wx_config;
 
 fn main() {
-    wx_config_cflags(&mut cc::Build::new())
+    let mut cc_build = cc::Build::new();
+    // from `wx-config --cflags`
+    for arg in wx_config(&["--cflags"]).iter() {
+        cc_build.flag(arg);
+    }
+    cc_build
         .cpp(true)
         .file("src/manual.cpp")
         .file("src/generated.cpp")

--- a/wx-core/Cargo.toml
+++ b/wx-core/Cargo.toml
@@ -29,4 +29,4 @@ wx-x86_64-pc-windows-msvc = { git = "https://github.com/kenz-gelsoft/wx-x86_64-p
 
 [build-dependencies]
 cc = "1.0.72"
-wxrust-config = "0.0.1-alpha"
+wxrust-config = "0.0.1-alpha2"

--- a/wx-core/build.rs
+++ b/wx-core/build.rs
@@ -7,6 +7,10 @@ fn main() {
         .file("src/generated.cpp")
         .include("include")
         .flag_if_supported("-std=c++14")
+        // ignore too many warnings with wx3.0
+        .flag_if_supported("-Wno-deprecated-copy")
+        .flag_if_supported("-Wno-ignored-qualifiers")
+        .flag_if_supported("-Wno-unused-parameter")
         .compile("wx");
 
     // from `wx-config --libs`

--- a/wx-core/build.rs
+++ b/wx-core/build.rs
@@ -1,4 +1,4 @@
-use wxrust_config::{print_wx_config_libs_for_cargo, wx_config_cflags};
+use wxrust_config::{wx_config, wx_config_cflags};
 
 fn main() {
     wx_config_cflags(&mut cc::Build::new())
@@ -9,5 +9,7 @@ fn main() {
         .flag_if_supported("-std=c++14")
         .compile("wx");
 
-    print_wx_config_libs_for_cargo();
+    // from `wx-config --libs`
+    let libs = wx_config(&["--libs"]);
+    println!("cargo:rustc-flags={}", libs.join(" "));
 }

--- a/wx-core/build.rs
+++ b/wx-core/build.rs
@@ -1,7 +1,12 @@
-use wxrust_config::{wx_config, wx_config_cflags};
+use wxrust_config::wx_config;
 
 fn main() {
-    wx_config_cflags(&mut cc::Build::new())
+    let mut cc_build = cc::Build::new();
+    // from `wx-config --cflags`
+    for arg in wx_config(&["--cflags"]).iter() {
+        cc_build.flag(arg);
+    }
+    cc_build
         .cpp(true)
         .file("src/manual.cpp")
         .file("src/generated.cpp")

--- a/wxrust-config/Cargo.toml
+++ b/wxrust-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wxrust-config"
-version = "0.0.1-alpha"
+version = "0.0.1-alpha2"
 edition = "2021"
 description = "Build support crate for wxrust packages."
 license = "MIT"

--- a/wxrust-config/src/lib.rs
+++ b/wxrust-config/src/lib.rs
@@ -9,8 +9,8 @@ pub fn wx_config_cflags(cc_build: &mut cc::Build) -> &mut cc::Build {
         .flag_if_supported("-Wno-deprecated-copy")
         .flag_if_supported("-Wno-ignored-qualifiers")
         .flag_if_supported("-Wno-unused-parameter");
-    for arg in cflags.split_whitespace() {
-        cc_build.flag(arg);
+    for arg in cflags {
+        cc_build.flag(&arg);
     }
     let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap();
     if target_env.eq("msvc") {
@@ -22,7 +22,7 @@ pub fn wx_config_cflags(cc_build: &mut cc::Build) -> &mut cc::Build {
 pub fn print_wx_config_libs_for_cargo() {
     // from `wx-config --libs`
     let libs = wx_config(&["--libs"]);
-    for arg in libs.split_whitespace() {
+    for arg in libs {
         println!("cargo:rustc-flags={}", arg);
     }
 }
@@ -36,7 +36,7 @@ fn dep_links() -> String {
     }
 }
 
-fn wx_config(args: &[&str]) -> String {
+fn wx_config(args: &[&str]) -> Vec<String> {
     if cfg!(feature = "vendored") {
         let flags: Vec<_> = env::var(format!("DEP_WX_{}_CFLAGS", dep_links()))
             .unwrap()
@@ -47,9 +47,9 @@ fn wx_config(args: &[&str]) -> String {
             .into_iter()
             .partition(|f| f.starts_with("-l") || f.starts_with("-L"));
         return if args.contains(&"--cflags") {
-            cflags.join(" ")
+            cflags
         } else {
-            ldflags.join(" ")
+            ldflags
         };
     }
 
@@ -60,11 +60,15 @@ fn wx_config(args: &[&str]) -> String {
             .args(args)
             .output()
             .expect("failed execute wx-config command.");
-        String::from_utf8_lossy(&output.stdout).to_string()
+        String::from_utf8_lossy(&output.stdout)
+            .to_string()
+            .split_whitespace()
+            .map(ToOwned::to_owned)
+            .collect()
     }
 }
 
-fn wx_config_win(args: &[&str]) -> String {
+fn wx_config_win(args: &[&str]) -> Vec<String> {
     let wxwin = env::var("wxwin")
         .expect("Set 'wxwin' environment variable to point the wxMSW binaries dir.");
     // TODO: support linking with the wx debug DLL
@@ -83,13 +87,13 @@ fn wx_config_win(args: &[&str]) -> String {
             cflags.push("-DwxDEBUG_LEVEL=0".to_string());
             cflags.push("-DNDEBUG".to_string());
         }
-        cflags.join(" ")
+        cflags
     } else {
         let libs = vec![
             format!("-L{}\\lib\\vc14x_x64_dll", wxwin),
             format!("-lwxbase32u{}", d_or_not),
             format!("-lwxmsw32u{}_core", d_or_not),
         ];
-        libs.join(" ")
+        libs
     }
 }

--- a/wxrust-config/src/lib.rs
+++ b/wxrust-config/src/lib.rs
@@ -10,16 +10,7 @@ pub fn wx_config_cflags(cc_build: &mut cc::Build) -> &mut cc::Build {
         .flag_if_supported("-Wno-ignored-qualifiers")
         .flag_if_supported("-Wno-unused-parameter");
     for arg in cflags.split_whitespace() {
-        if arg.starts_with("-I") {
-            cc_build.include(&arg[2..]);
-        } else if arg.starts_with("-D") {
-            let split = &mut arg[2..].split('=');
-            cc_build.define(split.next().unwrap(), split.next().unwrap_or(""));
-        } else if arg.starts_with("-pthread") {
-            cc_build.flag(arg);
-        } else {
-            panic!("unsupported argument '{}'. please file a bug.", arg)
-        }
+        cc_build.flag(arg);
     }
     let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap();
     if target_env.eq("msvc") {
@@ -31,22 +22,8 @@ pub fn wx_config_cflags(cc_build: &mut cc::Build) -> &mut cc::Build {
 pub fn print_wx_config_libs_for_cargo() {
     // from `wx-config --libs`
     let libs = wx_config(&["--libs"]);
-    let mut next_is_framework_name = false;
     for arg in libs.split_whitespace() {
-        if next_is_framework_name {
-            println!("cargo:rustc-link-lib=framework={}", arg);
-            next_is_framework_name = false;
-        } else if arg == "-framework" {
-            next_is_framework_name = true;
-        } else if arg.starts_with("-L") {
-            println!("cargo:rustc-link-search=native={}", &arg[2..]);
-        } else if arg.starts_with("-l") {
-            println!("cargo:rustc-link-lib={}", &arg[2..]);
-        } else if arg.starts_with("-pthread") {
-            // ignore
-        } else {
-            panic!("unsupported argument '{}'. please file a bug.", arg)
-        }
+        println!("cargo:rustc-flags={}", arg);
     }
 }
 

--- a/wxrust-config/src/lib.rs
+++ b/wxrust-config/src/lib.rs
@@ -1,6 +1,6 @@
 use std::env;
 
-#[cfg(feature = "vendored")]
+#[cfg(all(not(feature = "vendored"), not(windows)))]
 use std::process::Command;
 
 #[cfg(feature = "vendored")]

--- a/wxrust-config/src/lib.rs
+++ b/wxrust-config/src/lib.rs
@@ -36,7 +36,7 @@ fn dep_links() -> String {
 }
 
 #[cfg(feature = "vendored")]
-fn wx_config(args: &[&str]) -> Vec<String> {
+pub fn wx_config(args: &[&str]) -> Vec<String> {
     let flags: Vec<_> = env::var(format!("DEP_WX_{}_CFLAGS", dep_links()))
         .unwrap()
         .split_whitespace()
@@ -53,7 +53,7 @@ fn wx_config(args: &[&str]) -> Vec<String> {
 }
 
 #[cfg(all(not(feature = "vendored"), not(windows)))]
-fn wx_config(args: &[&str]) -> Vec<String> {
+pub fn wx_config(args: &[&str]) -> Vec<String> {
     let output = Command::new("wx-config")
         .args(args)
         .output()
@@ -66,7 +66,7 @@ fn wx_config(args: &[&str]) -> Vec<String> {
 }
 
 #[cfg(all(not(feature = "vendored"), windows))]
-fn wx_config(args: &[&str]) -> Vec<String> {
+pub fn wx_config(args: &[&str]) -> Vec<String> {
     let wxwin = env::var("wxwin")
         .expect("Set 'wxwin' environment variable to point the wxMSW binaries dir.");
     // TODO: support linking with the wx debug DLL

--- a/wxrust-config/src/lib.rs
+++ b/wxrust-config/src/lib.rs
@@ -1,14 +1,7 @@
 use std::env;
-use std::process::Command;
 
-pub fn wx_config_cflags(cc_build: &mut cc::Build) -> &mut cc::Build {
-    // from `wx-config --cflags`
-    let cflags = wx_config(&["--cflags"]);
-    for arg in cflags {
-        cc_build.flag(&arg);
-    }
-    cc_build
-}
+#[cfg(feature = "vendored")]
+use std::process::Command;
 
 #[cfg(feature = "vendored")]
 fn dep_links() -> String {

--- a/wxrust-config/src/lib.rs
+++ b/wxrust-config/src/lib.rs
@@ -22,9 +22,7 @@ pub fn wx_config_cflags(cc_build: &mut cc::Build) -> &mut cc::Build {
 pub fn print_wx_config_libs_for_cargo() {
     // from `wx-config --libs`
     let libs = wx_config(&["--libs"]);
-    for arg in libs {
-        println!("cargo:rustc-flags={}", arg);
-    }
+    println!("cargo:rustc-flags={}", libs.join(" "));
 }
 
 fn dep_links() -> String {

--- a/wxrust-config/src/lib.rs
+++ b/wxrust-config/src/lib.rs
@@ -19,12 +19,6 @@ pub fn wx_config_cflags(cc_build: &mut cc::Build) -> &mut cc::Build {
     cc_build
 }
 
-pub fn print_wx_config_libs_for_cargo() {
-    // from `wx-config --libs`
-    let libs = wx_config(&["--libs"]);
-    println!("cargo:rustc-flags={}", libs.join(" "));
-}
-
 #[cfg(feature = "vendored")]
 fn dep_links() -> String {
     let target = env::var("TARGET").unwrap().replace('-', "_").to_uppercase();

--- a/wxrust-config/src/lib.rs
+++ b/wxrust-config/src/lib.rs
@@ -7,10 +7,6 @@ pub fn wx_config_cflags(cc_build: &mut cc::Build) -> &mut cc::Build {
     for arg in cflags {
         cc_build.flag(&arg);
     }
-    let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap();
-    if target_env.eq("msvc") {
-        cc_build.flag("/EHsc");
-    }
     cc_build
 }
 
@@ -73,6 +69,10 @@ pub fn wx_config(args: &[&str]) -> Vec<String> {
             cflags.push("-D__NO_VC_CRTDBG__".to_string());
             cflags.push("-DwxDEBUG_LEVEL=0".to_string());
             cflags.push("-DNDEBUG".to_string());
+        }
+        let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap();
+        if target_env.eq("msvc") {
+            cflags.push("/EHsc".to_string());
         }
         cflags
     } else {

--- a/wxrust-config/src/lib.rs
+++ b/wxrust-config/src/lib.rs
@@ -4,11 +4,6 @@ use std::process::Command;
 pub fn wx_config_cflags(cc_build: &mut cc::Build) -> &mut cc::Build {
     // from `wx-config --cflags`
     let cflags = wx_config(&["--cflags"]);
-    // ignore too many warnings with wx3.0
-    cc_build
-        .flag_if_supported("-Wno-deprecated-copy")
-        .flag_if_supported("-Wno-ignored-qualifiers")
-        .flag_if_supported("-Wno-unused-parameter");
     for arg in cflags {
         cc_build.flag(&arg);
     }


### PR DESCRIPTION
For preparation to resolve #162

- Simplify logic.
- Reduce wxrust-config responsibility.
- This change breaks compatibility from wxrust-config 0.0.1-alpha.