### PR TITLE
Depends on vendored crates through newly created git-hosted wxrust-vendored-config crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,7 +86,7 @@ source = "git+https://github.com/ancwrd1/wx-x86_64-pc-windows-gnu#b41af996f76669
 [[package]]
 name = "wx-x86_64-pc-windows-msvc"
 version = "3.2.0"
-source = "git+https://github.com/kenz-gelsoft/wx-x86_64-pc-windows-msvc#ed36771152a5c03212bce34b17d95629e1f8f8a9"
+source = "git+https://github.com/kenz-gelsoft/wx-x86_64-pc-windows-msvc?branch=runtime_api#7214a610c0ac2c9588de7dc45a936b45ae8443d9"
 
 [[package]]
 name = "wxrust"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,20 +80,19 @@ source = "git+https://github.com/kenz-gelsoft/wx-universal-apple-darwin?branch=r
 
 [[package]]
 name = "wx-x86_64-pc-windows-gnu"
-version = "3.1.6"
-source = "git+https://github.com/ancwrd1/wx-x86_64-pc-windows-gnu#b41af996f766692e2d08926dbd2660091a654916"
+version = "3.2.0"
+source = "git+https://github.com/kenz-gelsoft/wx-x86_64-pc-windows-gnu?branch=runtime_api#a64384e4b5752c75cdb230d481074344213aadfb"
 
 [[package]]
 name = "wx-x86_64-pc-windows-msvc"
 version = "3.2.0"
-source = "git+https://github.com/kenz-gelsoft/wx-x86_64-pc-windows-msvc?branch=runtime_api#af0164988036609d3060e6bdb4ea168ec7d8b908"
+source = "git+https://github.com/kenz-gelsoft/wx-x86_64-pc-windows-msvc?branch=runtime_api#d8221552bc37e725aabe10a56b9b2aa55e40ab55"
 
 [[package]]
 name = "wxrust"
 version = "0.0.1-alpha"
 dependencies = [
  "cc",
- "wx-x86_64-pc-windows-gnu",
  "wxrust-base",
  "wxrust-config 0.0.1-alpha2 (git+https://github.com/kenz-gelsoft/wxrust-vendored-config)",
 ]
@@ -103,7 +102,6 @@ name = "wxrust-base"
 version = "0.0.1-alpha"
 dependencies = [
  "cc",
- "wx-x86_64-pc-windows-gnu",
  "wxrust-config 0.0.1-alpha2 (git+https://github.com/kenz-gelsoft/wxrust-vendored-config)",
 ]
 
@@ -117,8 +115,9 @@ dependencies = [
 [[package]]
 name = "wxrust-config"
 version = "0.0.1-alpha2"
-source = "git+https://github.com/kenz-gelsoft/wxrust-vendored-config#e646ac9190b801fbf4646cc5b69d7e6975f8988b"
+source = "git+https://github.com/kenz-gelsoft/wxrust-vendored-config#67a49d3f9501c353fa88c8e9f139a76786ada576"
 dependencies = [
  "wx-universal-apple-darwin",
+ "wx-x86_64-pc-windows-gnu",
  "wx-x86_64-pc-windows-msvc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,17 +76,17 @@ dependencies = [
 [[package]]
 name = "wx-universal-apple-darwin"
 version = "3.2.0"
-source = "git+https://github.com/kenz-gelsoft/wx-universal-apple-darwin?branch=runtime_api#b5eeda0ce803d4d2f9f3e9953339a30c8bc9e09b"
+source = "git+https://github.com/ancwrd1/wx-universal-apple-darwin#0471f55767008ca0e0d1a5c87ae91d892cdedc42"
 
 [[package]]
 name = "wx-x86_64-pc-windows-gnu"
 version = "3.2.0"
-source = "git+https://github.com/kenz-gelsoft/wx-x86_64-pc-windows-gnu?branch=runtime_api#a64384e4b5752c75cdb230d481074344213aadfb"
+source = "git+https://github.com/ancwrd1/wx-x86_64-pc-windows-gnu#00386ca3ae1337a21529af86e623f88b7ba0aae0"
 
 [[package]]
 name = "wx-x86_64-pc-windows-msvc"
 version = "3.2.0"
-source = "git+https://github.com/kenz-gelsoft/wx-x86_64-pc-windows-msvc?branch=runtime_api#d8221552bc37e725aabe10a56b9b2aa55e40ab55"
+source = "git+https://github.com/kenz-gelsoft/wx-x86_64-pc-windows-msvc#db0313072df2fc205847b81637ca1c145cf142f8"
 
 [[package]]
 name = "wxrust"
@@ -115,7 +115,7 @@ dependencies = [
 [[package]]
 name = "wxrust-config"
 version = "0.0.1-alpha2"
-source = "git+https://github.com/kenz-gelsoft/wxrust-vendored-config#a53b942318b11e5b35e8af39a9e253d379baff87"
+source = "git+https://github.com/kenz-gelsoft/wxrust-vendored-config#9872ba5061869d6cacac678e99e5b2c001ac47cd"
 dependencies = [
  "wx-universal-apple-darwin",
  "wx-x86_64-pc-windows-gnu",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ dependencies = [
 [[package]]
 name = "wxrust-config"
 version = "0.0.1-alpha2"
-source = "git+https://github.com/kenz-gelsoft/wxrust-vendored-config#05cbea9d021800d5b8d97beb54c29fc19b81adbd"
+source = "git+https://github.com/kenz-gelsoft/wxrust-vendored-config#c64171791fb00088f0ebd530fff675299e7518d3"
 dependencies = [
  "wx-x86_64-pc-windows-msvc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,6 +84,11 @@ version = "3.1.6"
 source = "git+https://github.com/ancwrd1/wx-x86_64-pc-windows-gnu#b41af996f766692e2d08926dbd2660091a654916"
 
 [[package]]
+name = "wx-x86_64-pc-windows-msvc"
+version = "3.2.0"
+source = "git+https://github.com/kenz-gelsoft/wx-x86_64-pc-windows-msvc?branch=runtime_api#5b4469224d9d76b7d0ac9b0bd8d0bececf594150"
+
+[[package]]
 name = "wxrust"
 version = "0.0.1-alpha"
 dependencies = [
@@ -91,7 +96,7 @@ dependencies = [
  "wx-universal-apple-darwin",
  "wx-x86_64-pc-windows-gnu",
  "wxrust-base",
- "wxrust-config 0.0.1-alpha2 (git+https://github.com/kenz-gelsoft/wx-x86_64-pc-windows-msvc?branch=runtime_api)",
+ "wxrust-config 0.0.1-alpha2 (git+https://github.com/kenz-gelsoft/wxrust-vendored-config)",
 ]
 
 [[package]]
@@ -101,7 +106,7 @@ dependencies = [
  "cc",
  "wx-universal-apple-darwin",
  "wx-x86_64-pc-windows-gnu",
- "wxrust-config 0.0.1-alpha2 (git+https://github.com/kenz-gelsoft/wx-x86_64-pc-windows-msvc?branch=runtime_api)",
+ "wxrust-config 0.0.1-alpha2 (git+https://github.com/kenz-gelsoft/wxrust-vendored-config)",
 ]
 
 [[package]]
@@ -114,4 +119,7 @@ dependencies = [
 [[package]]
 name = "wxrust-config"
 version = "0.0.1-alpha2"
-source = "git+https://github.com/kenz-gelsoft/wx-x86_64-pc-windows-msvc?branch=runtime_api#7bd975f8613ab3ef8186af1aa9f6882974040db1"
+source = "git+https://github.com/kenz-gelsoft/wxrust-vendored-config#05cbea9d021800d5b8d97beb54c29fc19b81adbd"
+dependencies = [
+ "wx-x86_64-pc-windows-msvc",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,20 +84,14 @@ version = "3.1.6"
 source = "git+https://github.com/ancwrd1/wx-x86_64-pc-windows-gnu#b41af996f766692e2d08926dbd2660091a654916"
 
 [[package]]
-name = "wx-x86_64-pc-windows-msvc"
-version = "3.2.0"
-source = "git+https://github.com/kenz-gelsoft/wx-x86_64-pc-windows-msvc?branch=runtime_api#7214a610c0ac2c9588de7dc45a936b45ae8443d9"
-
-[[package]]
 name = "wxrust"
 version = "0.0.1-alpha"
 dependencies = [
  "cc",
  "wx-universal-apple-darwin",
  "wx-x86_64-pc-windows-gnu",
- "wx-x86_64-pc-windows-msvc",
  "wxrust-base",
- "wxrust-config",
+ "wxrust-config 0.0.1-alpha2 (git+https://github.com/kenz-gelsoft/wx-x86_64-pc-windows-msvc?branch=runtime_api)",
 ]
 
 [[package]]
@@ -107,8 +101,7 @@ dependencies = [
  "cc",
  "wx-universal-apple-darwin",
  "wx-x86_64-pc-windows-gnu",
- "wx-x86_64-pc-windows-msvc",
- "wxrust-config",
+ "wxrust-config 0.0.1-alpha2 (git+https://github.com/kenz-gelsoft/wx-x86_64-pc-windows-msvc?branch=runtime_api)",
 ]
 
 [[package]]
@@ -117,3 +110,8 @@ version = "0.0.1-alpha2"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "wxrust-config"
+version = "0.0.1-alpha2"
+source = "git+https://github.com/kenz-gelsoft/wx-x86_64-pc-windows-msvc?branch=runtime_api#7bd975f8613ab3ef8186af1aa9f6882974040db1"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,7 +115,7 @@ dependencies = [
 [[package]]
 name = "wxrust-config"
 version = "0.0.1-alpha2"
-source = "git+https://github.com/kenz-gelsoft/wxrust-vendored-config#67a49d3f9501c353fa88c8e9f139a76786ada576"
+source = "git+https://github.com/kenz-gelsoft/wxrust-vendored-config#7af5b7bcf77a2b54acf34d6bc60546ad9a1c5ef5"
 dependencies = [
  "wx-universal-apple-darwin",
  "wx-x86_64-pc-windows-gnu",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,7 +86,7 @@ source = "git+https://github.com/ancwrd1/wx-x86_64-pc-windows-gnu#b41af996f76669
 [[package]]
 name = "wx-x86_64-pc-windows-msvc"
 version = "3.2.0"
-source = "git+https://github.com/kenz-gelsoft/wx-x86_64-pc-windows-msvc?branch=runtime_api#5b4469224d9d76b7d0ac9b0bd8d0bececf594150"
+source = "git+https://github.com/kenz-gelsoft/wx-x86_64-pc-windows-msvc?branch=runtime_api#af0164988036609d3060e6bdb4ea168ec7d8b908"
 
 [[package]]
 name = "wxrust"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,7 @@ dependencies = [
 [[package]]
 name = "wx-universal-apple-darwin"
 version = "3.2.0"
-source = "git+https://github.com/kenz-gelsoft/wx-universal-apple-darwin?branch=runtime_api#0cc56ca2f487fab5a52a60d3bc226d1bdd2ffcea"
+source = "git+https://github.com/kenz-gelsoft/wx-universal-apple-darwin?branch=runtime_api#b5eeda0ce803d4d2f9f3e9953339a30c8bc9e09b"
 
 [[package]]
 name = "wx-x86_64-pc-windows-gnu"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,8 +75,8 @@ dependencies = [
 
 [[package]]
 name = "wx-universal-apple-darwin"
-version = "3.1.6"
-source = "git+https://github.com/ancwrd1/wx-universal-apple-darwin#4e512d2c125436007a7ee1331a48d8b5de430fb4"
+version = "3.2.0"
+source = "git+https://github.com/kenz-gelsoft/wx-universal-apple-darwin?branch=runtime_api#0cc56ca2f487fab5a52a60d3bc226d1bdd2ffcea"
 
 [[package]]
 name = "wx-x86_64-pc-windows-gnu"
@@ -93,7 +93,6 @@ name = "wxrust"
 version = "0.0.1-alpha"
 dependencies = [
  "cc",
- "wx-universal-apple-darwin",
  "wx-x86_64-pc-windows-gnu",
  "wxrust-base",
  "wxrust-config 0.0.1-alpha2 (git+https://github.com/kenz-gelsoft/wxrust-vendored-config)",
@@ -104,7 +103,6 @@ name = "wxrust-base"
 version = "0.0.1-alpha"
 dependencies = [
  "cc",
- "wx-universal-apple-darwin",
  "wx-x86_64-pc-windows-gnu",
  "wxrust-config 0.0.1-alpha2 (git+https://github.com/kenz-gelsoft/wxrust-vendored-config)",
 ]
@@ -119,7 +117,8 @@ dependencies = [
 [[package]]
 name = "wxrust-config"
 version = "0.0.1-alpha2"
-source = "git+https://github.com/kenz-gelsoft/wxrust-vendored-config#c64171791fb00088f0ebd530fff675299e7518d3"
+source = "git+https://github.com/kenz-gelsoft/wxrust-vendored-config#e646ac9190b801fbf4646cc5b69d7e6975f8988b"
 dependencies = [
+ "wx-universal-apple-darwin",
  "wx-x86_64-pc-windows-msvc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,6 @@ members = [
     "wxrust-config",
 ]
 
-# [patch.crates-io]
+[patch.crates-io]
 # wxrust-config = { path = "wxrust-config" }
+wxrust-config = { git = "https://github.com/kenz-gelsoft/wx-x86_64-pc-windows-msvc", branch = "runtime_api" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,5 @@ members = [
     "wxrust-config",
 ]
 
-[patch.crates-io]
-wxrust-config = { path = "wxrust-config" }
+# [patch.crates-io]
+# wxrust-config = { path = "wxrust-config" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ members = [
 
 [patch.crates-io]
 # wxrust-config = { path = "wxrust-config" }
-wxrust-config = { git = "https://github.com/kenz-gelsoft/wx-x86_64-pc-windows-msvc", branch = "runtime_api" }
+wxrust-config = { git = "https://github.com/kenz-gelsoft/wxrust-vendored-config" }

--- a/Doxybindgen.toml
+++ b/Doxybindgen.toml
@@ -1178,10 +1178,11 @@ blocklist = [
 blocklist = [
     # some of our CI env built without printing
     'CreateContext3',
+    # our vendored crate doesn't support
+    'GetDirect2DRenderer',
 ]
 windows = [
     'CreateContext4',
-    'GetDirect2DRenderer',
     'GetGDIPlusRenderer',
 ]
 wx31 = [

--- a/Doxybindgen.toml
+++ b/Doxybindgen.toml
@@ -605,6 +605,10 @@ blocklist = [
     # - Not supported before 3.2.0
     'ResetAlpha',
     'UseAlpha',
+    # Some feature disabled in vendored create
+    'SetDepth',
+    'SetHeight',
+    'SetWidth',
 ]
 wx31 = [
     'wxBitmap5',
@@ -618,13 +622,6 @@ wx31 = [
     'GetLogicalWidth',
     'Rescale',
     'SetScaleFactor',
-]
-wx317 = [
-    # Doc isn't up-to-date in wx3.1.6
-    'wxBitmap9',
-    'SetDepth',
-    'SetHeight',
-    'SetWidth',
 ]
 not_windows = [
     # FIXME: FindHandler on MSW requires dynamic_cast in C++ generated code.
@@ -1281,17 +1278,15 @@ blocklist = [
 [types.wxIcon]
 blocklist = [
     'operator=',
+    # Some feature disabled in vendored create
+    'SetDepth',
+    'SetHeight',
+    'SetWidth',
 ]
 wx31 = [
     'GetLogicalHeight',
     'GetLogicalSize',
     'GetLogicalWidth',
-]
-wx317 = [
-    # Doc isn't up-to-date in wx3.1.6
-    'SetDepth',
-    'SetHeight',
-    'SetWidth',
 ]
 [types.wxIconBundle]
 blocklist = [
@@ -1591,8 +1586,8 @@ blocklist = [
     'wxPrintout',
 ]
 [types.wxRadioBox]
-wx317 = [
-    # Doc isn't up-to-date in wx3.1.6
+blocklist = [
+    # help disabled in vendored crate
     'GetItemHelpText',
 ]
 [types.wxRadioButton]
@@ -1985,9 +1980,7 @@ blocklist = [
     'GetChildren',
     'GetCursor',
     'GetUpdateRegion',
-]
-wx317 = [
-    # Doc isn't up-to-date in wx3.1.6
+    # help disabled in vendored crate
     'GetHelpText',
 ]
 not_gtk = [

--- a/Doxybindgen.toml
+++ b/Doxybindgen.toml
@@ -613,6 +613,7 @@ blocklist = [
 wx31 = [
     'wxBitmap5',
     'wxBitmap8',
+    'wxBitmap9',
     'wxBitmap10',
     'CreateWithDIPSize',
     'CreateWithDIPSize1',

--- a/README.md
+++ b/README.md
@@ -46,7 +46,18 @@ Following installation method are (somewhat) tested with:
 
 ### Use vendored wx binary crate
 
-Specify `--features vendored` to cargo, to use vendored prebuilt wx binary crate. This configuration links to following per-build-target crates by default. You should be able to [override this by crate name](https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html):
+You can use prebuilt wx binaries without installing wxWidgets system-wide.
+
+1. Specify `--features vendored` to cargo.
+2. Override `wxrust-config` crate dependency with the following git respositry crate (or your fork of it):
+    ```
+    [patch.crates-io]
+    wxrust-config = { git = "https://github.com/kenz-gelsoft/wxrust-vendored-config" }
+    ```
+
+(You need to specify git or local separate repo's crate, as `crates.io` won't host crates with (large) binary crates such as this.)
+
+This configuration links to following per-build-target crates by default. You should be able to [override this by crate name](https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html):
 
 |Build target|Crate name|Git repository|Build configuration|
 |------------|----------|--------------|-------------------|

--- a/README.md
+++ b/README.md
@@ -50,12 +50,11 @@ You can use prebuilt wx binaries without installing wxWidgets system-wide.
 
 1. Specify `--features vendored` to cargo.
 2. Override `wxrust-config` crate dependency with the following git respositry crate (or your fork of it):
-    ```
+    ```toml
     [patch.crates-io]
     wxrust-config = { git = "https://github.com/kenz-gelsoft/wxrust-vendored-config" }
     ```
-
-(You need to specify git or local separate repo's crate, as `crates.io` won't host crates with (large) binary crates such as this.)
+    - You need to specify git or local separate repo's crate, as `crates.io` won't host crates with (large) binary crates such as this.
 
 This configuration links to following per-build-target crates by default. You should be able to [override this by crate name](https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html):
 

--- a/wx-base/Cargo.toml
+++ b/wx-base/Cargo.toml
@@ -12,7 +12,6 @@ vendored = [
     "wxrust-config/vendored",
     "dep:wx-universal-apple-darwin",
     "dep:wx-x86_64-pc-windows-gnu",
-    "dep:wx-x86_64-pc-windows-msvc",
 ]
 
 [target.'cfg(target_os = "macos")'.dependencies]
@@ -21,9 +20,7 @@ wx-universal-apple-darwin = { git = "https://github.com/ancwrd1/wx-universal-app
 [target.x86_64-pc-windows-gnu.dependencies]
 wx-x86_64-pc-windows-gnu = { git = "https://github.com/ancwrd1/wx-x86_64-pc-windows-gnu", optional = true }
 
-[target.x86_64-pc-windows-msvc.dependencies]
-wx-x86_64-pc-windows-msvc = { git = "https://github.com/kenz-gelsoft/wx-x86_64-pc-windows-msvc", branch = "runtime_api", optional = true }
-
 [build-dependencies]
 cc = "1.0.72"
-wxrust-config = "0.0.1-alpha2"
+# wxrust-config = "0.0.1-alpha2"
+wxrust-config = { git = "https://github.com/kenz-gelsoft/wx-x86_64-pc-windows-msvc", branch = "runtime_api" }

--- a/wx-base/Cargo.toml
+++ b/wx-base/Cargo.toml
@@ -22,5 +22,4 @@ wx-x86_64-pc-windows-gnu = { git = "https://github.com/ancwrd1/wx-x86_64-pc-wind
 
 [build-dependencies]
 cc = "1.0.72"
-# wxrust-config = "0.0.1-alpha2"
-wxrust-config = { git = "https://github.com/kenz-gelsoft/wx-x86_64-pc-windows-msvc", branch = "runtime_api" }
+wxrust-config = "0.0.1-alpha2"

--- a/wx-base/Cargo.toml
+++ b/wx-base/Cargo.toml
@@ -10,12 +10,8 @@ license = "MIT"
 [features]
 vendored = [
     "wxrust-config/vendored",
-    "dep:wx-universal-apple-darwin",
     "dep:wx-x86_64-pc-windows-gnu",
 ]
-
-[target.'cfg(target_os = "macos")'.dependencies]
-wx-universal-apple-darwin = { git = "https://github.com/ancwrd1/wx-universal-apple-darwin", optional = true }
 
 [target.x86_64-pc-windows-gnu.dependencies]
 wx-x86_64-pc-windows-gnu = { git = "https://github.com/ancwrd1/wx-x86_64-pc-windows-gnu", optional = true }

--- a/wx-base/Cargo.toml
+++ b/wx-base/Cargo.toml
@@ -10,11 +10,7 @@ license = "MIT"
 [features]
 vendored = [
     "wxrust-config/vendored",
-    "dep:wx-x86_64-pc-windows-gnu",
 ]
-
-[target.x86_64-pc-windows-gnu.dependencies]
-wx-x86_64-pc-windows-gnu = { git = "https://github.com/ancwrd1/wx-x86_64-pc-windows-gnu", optional = true }
 
 [build-dependencies]
 cc = "1.0.72"

--- a/wx-base/Cargo.toml
+++ b/wx-base/Cargo.toml
@@ -22,7 +22,7 @@ wx-universal-apple-darwin = { git = "https://github.com/ancwrd1/wx-universal-app
 wx-x86_64-pc-windows-gnu = { git = "https://github.com/ancwrd1/wx-x86_64-pc-windows-gnu", optional = true }
 
 [target.x86_64-pc-windows-msvc.dependencies]
-wx-x86_64-pc-windows-msvc = { git = "https://github.com/kenz-gelsoft/wx-x86_64-pc-windows-msvc", optional = true }
+wx-x86_64-pc-windows-msvc = { git = "https://github.com/kenz-gelsoft/wx-x86_64-pc-windows-msvc", branch = "runtime_api", optional = true }
 
 [build-dependencies]
 cc = "1.0.72"

--- a/wx-core/Cargo.toml
+++ b/wx-core/Cargo.toml
@@ -25,5 +25,4 @@ wx-x86_64-pc-windows-gnu = { git = "https://github.com/ancwrd1/wx-x86_64-pc-wind
 
 [build-dependencies]
 cc = "1.0.72"
-# wxrust-config = "0.0.1-alpha2"
-wxrust-config = { git = "https://github.com/kenz-gelsoft/wx-x86_64-pc-windows-msvc", branch = "runtime_api" }
+wxrust-config = "0.0.1-alpha2"

--- a/wx-core/Cargo.toml
+++ b/wx-core/Cargo.toml
@@ -10,15 +10,11 @@ license = "MIT"
 [features]
 vendored = [
     "wxrust-config/vendored",
-    "dep:wx-universal-apple-darwin",
     "dep:wx-x86_64-pc-windows-gnu",
 ]
 
 [dependencies]
 wx-base = { path = "../wx-base", package="wxrust-base" }
-
-[target.'cfg(target_os = "macos")'.dependencies]
-wx-universal-apple-darwin = { git = "https://github.com/ancwrd1/wx-universal-apple-darwin", optional = true }
 
 [target.x86_64-pc-windows-gnu.dependencies]
 wx-x86_64-pc-windows-gnu = { git = "https://github.com/ancwrd1/wx-x86_64-pc-windows-gnu", optional = true }

--- a/wx-core/Cargo.toml
+++ b/wx-core/Cargo.toml
@@ -10,14 +10,10 @@ license = "MIT"
 [features]
 vendored = [
     "wxrust-config/vendored",
-    "dep:wx-x86_64-pc-windows-gnu",
 ]
 
 [dependencies]
 wx-base = { path = "../wx-base", package="wxrust-base" }
-
-[target.x86_64-pc-windows-gnu.dependencies]
-wx-x86_64-pc-windows-gnu = { git = "https://github.com/ancwrd1/wx-x86_64-pc-windows-gnu", optional = true }
 
 [build-dependencies]
 cc = "1.0.72"

--- a/wx-core/Cargo.toml
+++ b/wx-core/Cargo.toml
@@ -25,7 +25,7 @@ wx-universal-apple-darwin = { git = "https://github.com/ancwrd1/wx-universal-app
 wx-x86_64-pc-windows-gnu = { git = "https://github.com/ancwrd1/wx-x86_64-pc-windows-gnu", optional = true }
 
 [target.x86_64-pc-windows-msvc.dependencies]
-wx-x86_64-pc-windows-msvc = { git = "https://github.com/kenz-gelsoft/wx-x86_64-pc-windows-msvc", optional = true }
+wx-x86_64-pc-windows-msvc = { git = "https://github.com/kenz-gelsoft/wx-x86_64-pc-windows-msvc", branch = "runtime_api", optional = true }
 
 [build-dependencies]
 cc = "1.0.72"

--- a/wx-core/Cargo.toml
+++ b/wx-core/Cargo.toml
@@ -12,7 +12,6 @@ vendored = [
     "wxrust-config/vendored",
     "dep:wx-universal-apple-darwin",
     "dep:wx-x86_64-pc-windows-gnu",
-    "dep:wx-x86_64-pc-windows-msvc",
 ]
 
 [dependencies]
@@ -24,9 +23,7 @@ wx-universal-apple-darwin = { git = "https://github.com/ancwrd1/wx-universal-app
 [target.x86_64-pc-windows-gnu.dependencies]
 wx-x86_64-pc-windows-gnu = { git = "https://github.com/ancwrd1/wx-x86_64-pc-windows-gnu", optional = true }
 
-[target.x86_64-pc-windows-msvc.dependencies]
-wx-x86_64-pc-windows-msvc = { git = "https://github.com/kenz-gelsoft/wx-x86_64-pc-windows-msvc", branch = "runtime_api", optional = true }
-
 [build-dependencies]
 cc = "1.0.72"
-wxrust-config = "0.0.1-alpha2"
+# wxrust-config = "0.0.1-alpha2"
+wxrust-config = { git = "https://github.com/kenz-gelsoft/wx-x86_64-pc-windows-msvc", branch = "runtime_api" }

--- a/wx-core/include/generated/ffi_b.h
+++ b/wx-core/include/generated/ffi_b.h
@@ -40,9 +40,7 @@ wxBitmap *wxBitmap_new5(int width, int height, const wxDC * dc);
 wxBitmap *wxBitmap_new6(const char *const * bits);
 #if wxCHECK_VERSION(3, 1, 0)
 wxBitmap *wxBitmap_new8(const wxImage * img, int depth);
-#endif
 wxBitmap *wxBitmap_new9(const wxImage * img, const wxDC * dc);
-#if wxCHECK_VERSION(3, 1, 0)
 wxBitmap *wxBitmap_new10(const wxCursor * cursor);
 #endif
 wxImage *wxBitmap_ConvertToImage(const wxBitmap * self);

--- a/wx-core/include/generated/ffi_b.h
+++ b/wx-core/include/generated/ffi_b.h
@@ -41,9 +41,7 @@ wxBitmap *wxBitmap_new6(const char *const * bits);
 #if wxCHECK_VERSION(3, 1, 0)
 wxBitmap *wxBitmap_new8(const wxImage * img, int depth);
 #endif
-#if wxCHECK_VERSION(3, 1, 7)
 wxBitmap *wxBitmap_new9(const wxImage * img, const wxDC * dc);
-#endif
 #if wxCHECK_VERSION(3, 1, 0)
 wxBitmap *wxBitmap_new10(const wxCursor * cursor);
 #endif
@@ -78,18 +76,11 @@ wxSize *wxBitmap_GetSize(const wxBitmap * self);
 int wxBitmap_GetWidth(const wxBitmap * self);
 bool wxBitmap_HasAlpha(const wxBitmap * self);
 bool wxBitmap_IsOk(const wxBitmap * self);
-#if wxCHECK_VERSION(3, 1, 7)
-void wxBitmap_SetDepth(wxBitmap * self, int depth);
-void wxBitmap_SetHeight(wxBitmap * self, int height);
-#endif
 #if wxCHECK_VERSION(3, 1, 0)
 void wxBitmap_SetScaleFactor(wxBitmap * self, double scale);
 #endif
 void wxBitmap_SetMask(wxBitmap * self, wxMask * mask);
 void wxBitmap_SetPalette(wxBitmap * self, const wxPalette * palette);
-#if wxCHECK_VERSION(3, 1, 7)
-void wxBitmap_SetWidth(wxBitmap * self, int width);
-#endif
 void wxBitmap_AddHandler(wxBitmapHandler * handler);
 void wxBitmap_CleanUpHandlers();
 #ifndef __WXMSW__

--- a/wx-core/include/generated/ffi_g.h
+++ b/wx-core/include/generated/ffi_g.h
@@ -293,7 +293,6 @@ wxGraphicsRenderer * wxGraphicsRenderer_GetDefaultRenderer();
 wxGraphicsRenderer * wxGraphicsRenderer_GetCairoRenderer();
 #ifdef __WXMSW__
 wxGraphicsRenderer * wxGraphicsRenderer_GetGDIPlusRenderer();
-wxGraphicsRenderer * wxGraphicsRenderer_GetDirect2DRenderer();
 #endif
 
 // CLASS: wxGridBagSizer

--- a/wx-core/include/generated/ffi_i.h
+++ b/wx-core/include/generated/ffi_i.h
@@ -29,11 +29,6 @@ double wxIcon_GetScaleFactor(const wxIcon * self);
 wxSize *wxIcon_GetSize(const wxIcon * self);
 int wxIcon_GetWidth(const wxIcon * self);
 bool wxIcon_IsOk(const wxIcon * self);
-#if wxCHECK_VERSION(3, 1, 7)
-void wxIcon_SetDepth(wxIcon * self, int depth);
-void wxIcon_SetHeight(wxIcon * self, int height);
-void wxIcon_SetWidth(wxIcon * self, int width);
-#endif
 
 // CLASS: wxIconBundle
 wxClassInfo *wxIconBundle_CLASSINFO();

--- a/wx-core/include/generated/ffi_r.h
+++ b/wx-core/include/generated/ffi_r.h
@@ -18,9 +18,6 @@ bool wxRadioBox_Create1(wxRadioBox * self, wxWindow * parent, wxWindowID id, con
 bool wxRadioBox_Enable(wxRadioBox * self, unsigned int n, bool enable);
 unsigned int wxRadioBox_GetColumnCount(const wxRadioBox * self);
 int wxRadioBox_GetItemFromPoint(const wxRadioBox * self, const wxPoint * pt);
-#if wxCHECK_VERSION(3, 1, 7)
-wxString *wxRadioBox_GetItemHelpText(const wxRadioBox * self, unsigned int item);
-#endif
 wxToolTip * wxRadioBox_GetItemToolTip(const wxRadioBox * self, unsigned int item);
 unsigned int wxRadioBox_GetRowCount(const wxRadioBox * self);
 bool wxRadioBox_IsItemEnabled(const wxRadioBox * self, unsigned int n);

--- a/wx-core/include/generated/ffi_w.h
+++ b/wx-core/include/generated/ffi_w.h
@@ -236,9 +236,6 @@ bool wxWindow_IsShownOnScreen(const wxWindow * self);
 bool wxWindow_Disable(wxWindow * self);
 bool wxWindow_Enable(wxWindow * self, bool enable);
 bool wxWindow_Show(wxWindow * self, bool show);
-#if wxCHECK_VERSION(3, 1, 7)
-wxString *wxWindow_GetHelpText(const wxWindow * self);
-#endif
 void wxWindow_SetHelpText(wxWindow * self, const wxString * help_text);
 wxToolTip * wxWindow_GetToolTip(const wxWindow * self);
 wxString *wxWindow_GetToolTipText(const wxWindow * self);

--- a/wx-core/src/generated/ffi_b.cpp
+++ b/wx-core/src/generated/ffi_b.cpp
@@ -53,11 +53,9 @@ wxBitmap *wxBitmap_new6(const char *const * bits) {
 wxBitmap *wxBitmap_new8(const wxImage * img, int depth) {
     return new wxBitmap(*img, depth);
 }
-#endif
 wxBitmap *wxBitmap_new9(const wxImage * img, const wxDC * dc) {
     return new wxBitmap(*img, *dc);
 }
-#if wxCHECK_VERSION(3, 1, 0)
 wxBitmap *wxBitmap_new10(const wxCursor * cursor) {
     return new wxBitmap(*cursor);
 }

--- a/wx-core/src/generated/ffi_b.cpp
+++ b/wx-core/src/generated/ffi_b.cpp
@@ -54,11 +54,9 @@ wxBitmap *wxBitmap_new8(const wxImage * img, int depth) {
     return new wxBitmap(*img, depth);
 }
 #endif
-#if wxCHECK_VERSION(3, 1, 7)
 wxBitmap *wxBitmap_new9(const wxImage * img, const wxDC * dc) {
     return new wxBitmap(*img, *dc);
 }
-#endif
 #if wxCHECK_VERSION(3, 1, 0)
 wxBitmap *wxBitmap_new10(const wxCursor * cursor) {
     return new wxBitmap(*cursor);
@@ -145,14 +143,6 @@ bool wxBitmap_HasAlpha(const wxBitmap * self) {
 bool wxBitmap_IsOk(const wxBitmap * self) {
     return self->IsOk();
 }
-#if wxCHECK_VERSION(3, 1, 7)
-void wxBitmap_SetDepth(wxBitmap * self, int depth) {
-    return self->SetDepth(depth);
-}
-void wxBitmap_SetHeight(wxBitmap * self, int height) {
-    return self->SetHeight(height);
-}
-#endif
 #if wxCHECK_VERSION(3, 1, 0)
 void wxBitmap_SetScaleFactor(wxBitmap * self, double scale) {
     return self->SetScaleFactor(scale);
@@ -164,11 +154,6 @@ void wxBitmap_SetMask(wxBitmap * self, wxMask * mask) {
 void wxBitmap_SetPalette(wxBitmap * self, const wxPalette * palette) {
     return self->SetPalette(*palette);
 }
-#if wxCHECK_VERSION(3, 1, 7)
-void wxBitmap_SetWidth(wxBitmap * self, int width) {
-    return self->SetWidth(width);
-}
-#endif
 void wxBitmap_AddHandler(wxBitmapHandler * handler) {
     return wxBitmap::AddHandler(handler);
 }

--- a/wx-core/src/generated/ffi_b.rs
+++ b/wx-core/src/generated/ffi_b.rs
@@ -94,12 +94,12 @@ extern "C" {
     // NOT_SUPPORTED: pub fn wxBitmap_LoadFile(self_: *mut c_void, name: *const c_void, type_: wxBitmapType) -> bool;
     // BLOCKED: pub fn wxBitmap_ResetAlpha(self_: *mut c_void);
     // NOT_SUPPORTED: pub fn wxBitmap_SaveFile(self_: *const c_void, name: *const c_void, type_: wxBitmapType, palette: *const c_void) -> bool;
-    pub fn wxBitmap_SetDepth(self_: *mut c_void, depth: c_int);
-    pub fn wxBitmap_SetHeight(self_: *mut c_void, height: c_int);
+    // BLOCKED: pub fn wxBitmap_SetDepth(self_: *mut c_void, depth: c_int);
+    // BLOCKED: pub fn wxBitmap_SetHeight(self_: *mut c_void, height: c_int);
     pub fn wxBitmap_SetScaleFactor(self_: *mut c_void, scale: c_double);
     pub fn wxBitmap_SetMask(self_: *mut c_void, mask: *mut c_void);
     pub fn wxBitmap_SetPalette(self_: *mut c_void, palette: *const c_void);
-    pub fn wxBitmap_SetWidth(self_: *mut c_void, width: c_int);
+    // BLOCKED: pub fn wxBitmap_SetWidth(self_: *mut c_void, width: c_int);
     // BLOCKED: pub fn wxBitmap_UseAlpha(self_: *mut c_void, use_: bool) -> bool;
     pub fn wxBitmap_AddHandler(handler: *mut c_void);
     pub fn wxBitmap_CleanUpHandlers();

--- a/wx-core/src/generated/ffi_g.cpp
+++ b/wx-core/src/generated/ffi_g.cpp
@@ -704,9 +704,6 @@ wxGraphicsRenderer * wxGraphicsRenderer_GetCairoRenderer() {
 wxGraphicsRenderer * wxGraphicsRenderer_GetGDIPlusRenderer() {
     return wxGraphicsRenderer::GetGDIPlusRenderer();
 }
-wxGraphicsRenderer * wxGraphicsRenderer_GetDirect2DRenderer() {
-    return wxGraphicsRenderer::GetDirect2DRenderer();
-}
 #endif
 
 // CLASS: wxGridBagSizer

--- a/wx-core/src/generated/ffi_g.rs
+++ b/wx-core/src/generated/ffi_g.rs
@@ -538,7 +538,7 @@ extern "C" {
     pub fn wxGraphicsRenderer_GetDefaultRenderer() -> *mut c_void;
     pub fn wxGraphicsRenderer_GetCairoRenderer() -> *mut c_void;
     pub fn wxGraphicsRenderer_GetGDIPlusRenderer() -> *mut c_void;
-    pub fn wxGraphicsRenderer_GetDirect2DRenderer() -> *mut c_void;
+    // BLOCKED: pub fn wxGraphicsRenderer_GetDirect2DRenderer() -> *mut c_void;
 
     // wxGridBagSizer
     pub fn wxGridBagSizer_CLASSINFO() -> *mut c_void;

--- a/wx-core/src/generated/ffi_i.cpp
+++ b/wx-core/src/generated/ffi_i.cpp
@@ -50,17 +50,6 @@ int wxIcon_GetWidth(const wxIcon * self) {
 bool wxIcon_IsOk(const wxIcon * self) {
     return self->IsOk();
 }
-#if wxCHECK_VERSION(3, 1, 7)
-void wxIcon_SetDepth(wxIcon * self, int depth) {
-    return self->SetDepth(depth);
-}
-void wxIcon_SetHeight(wxIcon * self, int height) {
-    return self->SetHeight(height);
-}
-void wxIcon_SetWidth(wxIcon * self, int width) {
-    return self->SetWidth(width);
-}
-#endif
 
 // CLASS: wxIconBundle
 wxClassInfo *wxIconBundle_CLASSINFO() {

--- a/wx-core/src/generated/ffi_i.rs
+++ b/wx-core/src/generated/ffi_i.rs
@@ -24,9 +24,9 @@ extern "C" {
     pub fn wxIcon_GetWidth(self_: *const c_void) -> c_int;
     pub fn wxIcon_IsOk(self_: *const c_void) -> bool;
     // NOT_SUPPORTED: pub fn wxIcon_LoadFile(self_: *mut c_void, name: *const c_void, type_: wxBitmapType, desired_width: c_int, desired_height: c_int) -> bool;
-    pub fn wxIcon_SetDepth(self_: *mut c_void, depth: c_int);
-    pub fn wxIcon_SetHeight(self_: *mut c_void, height: c_int);
-    pub fn wxIcon_SetWidth(self_: *mut c_void, width: c_int);
+    // BLOCKED: pub fn wxIcon_SetDepth(self_: *mut c_void, depth: c_int);
+    // BLOCKED: pub fn wxIcon_SetHeight(self_: *mut c_void, height: c_int);
+    // BLOCKED: pub fn wxIcon_SetWidth(self_: *mut c_void, width: c_int);
     // BLOCKED: pub fn wxIcon_operator=(self_: *mut c_void, icon: *const c_void) -> *mut c_void;
 
     // wxIconBundle

--- a/wx-core/src/generated/ffi_r.cpp
+++ b/wx-core/src/generated/ffi_r.cpp
@@ -24,11 +24,6 @@ unsigned int wxRadioBox_GetColumnCount(const wxRadioBox * self) {
 int wxRadioBox_GetItemFromPoint(const wxRadioBox * self, const wxPoint * pt) {
     return self->GetItemFromPoint(*pt);
 }
-#if wxCHECK_VERSION(3, 1, 7)
-wxString *wxRadioBox_GetItemHelpText(const wxRadioBox * self, unsigned int item) {
-    return new wxString(self->GetItemHelpText(item));
-}
-#endif
 wxToolTip * wxRadioBox_GetItemToolTip(const wxRadioBox * self, unsigned int item) {
     return self->GetItemToolTip(item);
 }

--- a/wx-core/src/generated/ffi_r.rs
+++ b/wx-core/src/generated/ffi_r.rs
@@ -36,7 +36,7 @@ extern "C" {
     pub fn wxRadioBox_Enable(self_: *mut c_void, n: c_uint, enable: bool) -> bool;
     pub fn wxRadioBox_GetColumnCount(self_: *const c_void) -> c_uint;
     pub fn wxRadioBox_GetItemFromPoint(self_: *const c_void, pt: *const c_void) -> c_int;
-    pub fn wxRadioBox_GetItemHelpText(self_: *const c_void, item: c_uint) -> *mut c_void;
+    // BLOCKED: pub fn wxRadioBox_GetItemHelpText(self_: *const c_void, item: c_uint) -> wxString;
     pub fn wxRadioBox_GetItemToolTip(self_: *const c_void, item: c_uint) -> *mut c_void;
     pub fn wxRadioBox_GetRowCount(self_: *const c_void) -> c_uint;
     pub fn wxRadioBox_IsItemEnabled(self_: *const c_void, n: c_uint) -> bool;

--- a/wx-core/src/generated/ffi_w.cpp
+++ b/wx-core/src/generated/ffi_w.cpp
@@ -649,11 +649,6 @@ bool wxWindow_Enable(wxWindow * self, bool enable) {
 bool wxWindow_Show(wxWindow * self, bool show) {
     return self->Show(show);
 }
-#if wxCHECK_VERSION(3, 1, 7)
-wxString *wxWindow_GetHelpText(const wxWindow * self) {
-    return new wxString(self->GetHelpText());
-}
-#endif
 void wxWindow_SetHelpText(wxWindow * self, const wxString * help_text) {
     return self->SetHelpText(*help_text);
 }

--- a/wx-core/src/generated/ffi_w.rs
+++ b/wx-core/src/generated/ffi_w.rs
@@ -269,7 +269,7 @@ extern "C" {
     pub fn wxWindow_Enable(self_: *mut c_void, enable: bool) -> bool;
     pub fn wxWindow_Show(self_: *mut c_void, show: bool) -> bool;
     // NOT_SUPPORTED: pub fn wxWindow_ShowWithEffect(self_: *mut c_void, effect: wxShowEffect, timeout: c_uint) -> bool;
-    pub fn wxWindow_GetHelpText(self_: *const c_void) -> *mut c_void;
+    // BLOCKED: pub fn wxWindow_GetHelpText(self_: *const c_void) -> wxString;
     pub fn wxWindow_SetHelpText(self_: *mut c_void, help_text: *const c_void);
     // NOT_SUPPORTED: pub fn wxWindow_GetHelpTextAtPoint(self_: *const c_void, point: *const c_void, origin: wxHelpEvent::Origin) -> *mut c_void;
     pub fn wxWindow_GetToolTip(self_: *const c_void) -> *mut c_void;

--- a/wx-core/src/generated/methods_b.rs
+++ b/wx-core/src/generated/methods_b.rs
@@ -255,16 +255,8 @@ pub trait BitmapMethods: GDIObjectMethods {
     // NOT_SUPPORTED: fn LoadFile()
     // BLOCKED: fn ResetAlpha()
     // NOT_SUPPORTED: fn SaveFile()
-    ///
-    /// See [C++ `wxBitmap::SetDepth()`'s documentation](https://docs.wxwidgets.org/3.2/classwx_bitmap.html#ac2d3b023cf64f90fa1257eb874ed015e).
-    fn set_depth(&self, depth: c_int) {
-        unsafe { ffi::wxBitmap_SetDepth(self.as_ptr(), depth) }
-    }
-    ///
-    /// See [C++ `wxBitmap::SetHeight()`'s documentation](https://docs.wxwidgets.org/3.2/classwx_bitmap.html#a0091921ee85f7444e846e6183ec64909).
-    fn set_height(&self, height: c_int) {
-        unsafe { ffi::wxBitmap_SetHeight(self.as_ptr(), height) }
-    }
+    // BLOCKED: fn SetDepth()
+    // BLOCKED: fn SetHeight()
     /// Sets the bitmap scale factor.
     ///
     /// See [C++ `wxBitmap::SetScaleFactor()`'s documentation](https://docs.wxwidgets.org/3.2/classwx_bitmap.html#a096efa16cbdecd6ad9ebb65ce3b65407).
@@ -292,11 +284,7 @@ pub trait BitmapMethods: GDIObjectMethods {
             ffi::wxBitmap_SetPalette(self.as_ptr(), palette)
         }
     }
-    ///
-    /// See [C++ `wxBitmap::SetWidth()`'s documentation](https://docs.wxwidgets.org/3.2/classwx_bitmap.html#a82c54a43db80f31c9ff70b0e18a1d972).
-    fn set_width(&self, width: c_int) {
-        unsafe { ffi::wxBitmap_SetWidth(self.as_ptr(), width) }
-    }
+    // BLOCKED: fn SetWidth()
     // BLOCKED: fn UseAlpha()
     /// Adds a handler to the end of the static list of format handlers.
     ///

--- a/wx-core/src/generated/methods_g.rs
+++ b/wx-core/src/generated/methods_g.rs
@@ -1628,12 +1628,7 @@ pub trait GraphicsRendererMethods: ObjectMethods {
     fn get_gdi_plus_renderer() -> Option<GraphicsRendererIsOwned<false>> {
         unsafe { GraphicsRenderer::option_from(ffi::wxGraphicsRenderer_GetGDIPlusRenderer()) }
     }
-    /// Returns Direct2D renderer (MSW only).
-    ///
-    /// See [C++ `wxGraphicsRenderer::GetDirect2DRenderer()`'s documentation](https://docs.wxwidgets.org/3.2/classwx_graphics_renderer.html#afb1995eef02b02c7724dcd90443c1c2d).
-    fn get_direct2_d_renderer() -> Option<GraphicsRendererIsOwned<false>> {
-        unsafe { GraphicsRenderer::option_from(ffi::wxGraphicsRenderer_GetDirect2DRenderer()) }
-    }
+    // BLOCKED: fn GetDirect2DRenderer()
 }
 
 // wxGridBagSizer

--- a/wx-core/src/generated/methods_i.rs
+++ b/wx-core/src/generated/methods_i.rs
@@ -72,21 +72,9 @@ pub trait IconMethods: GDIObjectMethods {
         unsafe { ffi::wxIcon_IsOk(self.as_ptr()) }
     }
     // NOT_SUPPORTED: fn LoadFile()
-    ///
-    /// See [C++ `wxIcon::SetDepth()`'s documentation](https://docs.wxwidgets.org/3.2/classwx_icon.html#ae2099848c41aa2031fe70649c9279816).
-    fn set_depth(&self, depth: c_int) {
-        unsafe { ffi::wxIcon_SetDepth(self.as_ptr(), depth) }
-    }
-    ///
-    /// See [C++ `wxIcon::SetHeight()`'s documentation](https://docs.wxwidgets.org/3.2/classwx_icon.html#a5c5d857cd6fda4ecc05ba4820d4aa2fe).
-    fn set_height(&self, height: c_int) {
-        unsafe { ffi::wxIcon_SetHeight(self.as_ptr(), height) }
-    }
-    ///
-    /// See [C++ `wxIcon::SetWidth()`'s documentation](https://docs.wxwidgets.org/3.2/classwx_icon.html#add437e80330ad01742421d2b1d66e2d5).
-    fn set_width(&self, width: c_int) {
-        unsafe { ffi::wxIcon_SetWidth(self.as_ptr(), width) }
-    }
+    // BLOCKED: fn SetDepth()
+    // BLOCKED: fn SetHeight()
+    // BLOCKED: fn SetWidth()
     // BLOCKED: fn operator=()
 }
 

--- a/wx-core/src/generated/methods_r.rs
+++ b/wx-core/src/generated/methods_r.rs
@@ -78,12 +78,7 @@ pub trait RadioBoxMethods: ControlMethods {
             ffi::wxRadioBox_GetItemFromPoint(self.as_ptr(), pt)
         }
     }
-    /// Returns the helptext associated with the specified item if any or wxEmptyString.
-    ///
-    /// See [C++ `wxRadioBox::GetItemHelpText()`'s documentation](https://docs.wxwidgets.org/3.2/classwx_radio_box.html#a46c5a252960ba84c10074f462bb6499f).
-    fn get_item_help_text(&self, item: c_uint) -> String {
-        unsafe { WxString::from_ptr(ffi::wxRadioBox_GetItemHelpText(self.as_ptr(), item)).into() }
-    }
+    // BLOCKED: fn GetItemHelpText()
     /// Returns the tooltip associated with the specified item if any or NULL.
     ///
     /// See [C++ `wxRadioBox::GetItemToolTip()`'s documentation](https://docs.wxwidgets.org/3.2/classwx_radio_box.html#aae17bd6b2707de2d93ab1fba78850a41).

--- a/wx-core/src/generated/methods_w.rs
+++ b/wx-core/src/generated/methods_w.rs
@@ -1626,12 +1626,7 @@ pub trait WindowMethods: EvtHandlerMethods {
         unsafe { ffi::wxWindow_Show(self.as_ptr(), show) }
     }
     // NOT_SUPPORTED: fn ShowWithEffect()
-    /// Gets the help text to be used as context-sensitive help for this window.
-    ///
-    /// See [C++ `wxWindow::GetHelpText()`'s documentation](https://docs.wxwidgets.org/3.2/classwx_window.html#acb28971fe25abd1f5c6d768e203a042a).
-    fn get_help_text(&self) -> String {
-        unsafe { WxString::from_ptr(ffi::wxWindow_GetHelpText(self.as_ptr())).into() }
-    }
+    // BLOCKED: fn GetHelpText()
     /// Sets the help text to be used as context-sensitive help for this window.
     ///
     /// See [C++ `wxWindow::SetHelpText()`'s documentation](https://docs.wxwidgets.org/3.2/classwx_window.html#a4c1a2cbc7363237b3a7c70af4e702c72).


### PR DESCRIPTION
Closes #162

- Move dependencies on vendored repo out into another git repo crate https://github.com/kenz-gelsoft/wxrust-vendored-config
- This depends on following repos' PRs:
  - https://github.com/ancwrd1/wx-x86_64-pc-windows-gnu/pull/1
  - https://github.com/ancwrd1/wx-universal-apple-darwin/pull/1

---

TODO:
- [x] update README