### PR TITLE
Fix args handling

### DIFF
--- a/samples/hello/src/main.rs
+++ b/samples/hello/src/main.rs
@@ -10,8 +10,12 @@ use wx::methods::*;
 
 fn main() {
     wx::App::run(|_| {
+        let mut first_arg = "世界".to_owned();
+        if let Some(arg) = wx::App::args().nth(1) {
+            first_arg = arg;
+        }
         let frame = wx::Frame::builder(wx::Window::none())
-            .title("Hello, 世界")
+            .title(&format!("Hello, {}", first_arg))
             .build();
         let button = wx::Button::builder(Some(&frame)).label("Greet").build();
         let i = 3;

--- a/wx-base/include/manual.h
+++ b/wx-base/include/manual.h
@@ -44,6 +44,9 @@ class App : public wxApp {
     virtual bool OnInit();
 };
 
+int wxApp_argc();
+wxString *wxApp_argv(int i);
+
 void wxObject_delete(wxObject *self);
 
 void wxEvtHandler_Bind(wxEvtHandler *evtHandler, int eventType, void *aFn, void *aParam);

--- a/wx-base/include/manual.h
+++ b/wx-base/include/manual.h
@@ -83,6 +83,11 @@ void *OpaqueWeakRef_copy(void *obj);
 void OpaqueWeakRef_delete(void *self);
 void *OpaqueWeakRef_Get(void *self);
 
-int wxRustEntry(int *argc, wxChar **argv);
+#ifdef __WXMSW__
+typedef wxChar ArgChar;
+#else
+typedef char ArgChar;
+#endif // __WXMSW__
+int wxRustEntry(int *argc, ArgChar **argv);
 
 } // extern "C"

--- a/wx-base/include/manual.h
+++ b/wx-base/include/manual.h
@@ -83,6 +83,6 @@ void *OpaqueWeakRef_copy(void *obj);
 void OpaqueWeakRef_delete(void *self);
 void *OpaqueWeakRef_Get(void *self);
 
-int wxRustEntry(int *argc, char **argv);
+int wxRustEntry(int *argc, wxChar **argv);
 
 } // extern "C"

--- a/wx-base/src/manual.cpp
+++ b/wx-base/src/manual.cpp
@@ -129,6 +129,6 @@ void *OpaqueWeakRef_Get(void *self) {
     return weakRef->Get();
 }
 
-int wxRustEntry(int *argc, wxChar **argv) {
+int wxRustEntry(int *argc, ArgChar **argv) {
     return wxEntry(*argc, argv);
 }

--- a/wx-base/src/manual.cpp
+++ b/wx-base/src/manual.cpp
@@ -15,6 +15,13 @@ bool App::OnInit() {
     return true;
 }
 
+int wxApp_argc() {
+    return wxGetApp().argc;
+}
+wxString *wxApp_argv(int i) {
+    return new wxString(wxGetApp().argv[i]);
+}
+
 void wxObject_delete(wxObject *self) {
     delete self;
 }

--- a/wx-base/src/manual.cpp
+++ b/wx-base/src/manual.cpp
@@ -129,6 +129,6 @@ void *OpaqueWeakRef_Get(void *self) {
     return weakRef->Get();
 }
 
-int wxRustEntry(int *argc, char **argv) {
+int wxRustEntry(int *argc, wxChar **argv) {
     return wxEntry(*argc, argv);
 }


### PR DESCRIPTION
- [x] pass unicode (wide strings) on windows
- [x] add wx::App::args() fn to retrieve args  after wx handled
- [x] some testing