### PR TITLE
added from trait to wx::ArrayString and updated sample code

### DIFF
--- a/samples/widgets/src/button.rs
+++ b/samples/widgets/src/button.rs
@@ -186,14 +186,9 @@ impl WidgetsPage for ButtonWidgetsPage {
 
         sizer_left.add_spacer(10);
 
-        let dirs = wx::ArrayString::new();
-        dirs.add("left");
-        dirs.add("right");
-        dirs.add("top");
-        dirs.add("bottom");
         let radio_image_pos = wx::RadioBox::builder(Some(&self.base))
             .label("Image &position")
-            .choices(dirs)
+            .choices(["left", "right", "top", "bottom"].into())
             .build();
         sizer_left.add_window_sizerflags(
             Some(&radio_image_pos),
@@ -201,22 +196,14 @@ impl WidgetsPage for ButtonWidgetsPage {
         );
         sizer_left.add_spacer(15);
 
-        let halign = wx::ArrayString::new();
-        halign.add("left");
-        halign.add("centre");
-        halign.add("right");
         let radio_halign = wx::RadioBox::builder(Some(&self.base))
             .label("&Horz alignment")
-            .choices(halign)
+            .choices(["left", "centre", "right"].into())
             .build();
 
-        let valign = wx::ArrayString::new();
-        valign.add("top");
-        valign.add("centre");
-        valign.add("bottom");
         let radio_valign = wx::RadioBox::builder(Some(&self.base))
             .label("&Vert alignment")
-            .choices(valign)
+            .choices(["top", "centre", "bottom"].into())
             .build();
 
         sizer_left.add_window_sizerflags(

--- a/samples/widgets/src/checkbox.rs
+++ b/samples/widgets/src/checkbox.rs
@@ -103,10 +103,12 @@ impl WidgetsPage for CheckBoxWidgetsPage {
 
         sizer_left.add_spacer(10);
 
-        let kinds = wx::ArrayString::new();
-        kinds.add("usual &2-state checkbox");
-        kinds.add("&3rd state settable by program");
-        kinds.add("&user-settable 3rd state");
+        let kinds = [
+            "usual &2-state checkbox",
+            "&3rd state settable by program",
+            "&user-settable 3rd state",
+        ]
+        .into();
         let radio_kind = wx::RadioBox::builder(Some(&self.base))
             .label("&Kind")
             .choices(kinds)

--- a/samples/widgets/src/combobox.rs
+++ b/samples/widgets/src/combobox.rs
@@ -149,14 +149,9 @@ impl WidgetsPage for ComboboxWidgetsPage {
         // upper left pane
 
         // should be in sync with ComboKind_XXX values
-        let kinds = wx::ArrayString::new();
-        kinds.add("default");
-        kinds.add("simple");
-        kinds.add("drop down");
-
         let radio_kind = wx::RadioBox::builder(Some(&self.base))
             .label("Combobox &kind:")
-            .choices(kinds)
+            .choices(["default", "simple", "drop down"].into())
             .major_dimension(1)
             .style(wx::RA_SPECIFY_COLS.into())
             .build();
@@ -658,10 +653,12 @@ impl ComboboxWidgetsPage {
     }
 
     fn on_button_add_several(&self) {
-        let items = wx::ArrayString::new();
-        items.add("First");
-        items.add("another one");
-        items.add("and the last (very very very very very very very very very very long) one");
+        let items: wx::ArrayString = [
+            "First",
+            "another one",
+            "and the last (very very very very very very very very very very long) one",
+        ]
+        .into();
         if let Some(combobox) = self.combobox.borrow().as_ref() {
             combobox.insert_arraystring(&items, 0);
         }

--- a/samples/widgets/src/datepicker.rs
+++ b/samples/widgets/src/datepicker.rs
@@ -82,12 +82,8 @@ impl WidgetsPage for DatePickerWidgetsPage {
         // left pane: style
         let sizer_left = wx::BoxSizer::new(wx::VERTICAL);
 
-        let kinds = wx::ArrayString::new();
-        kinds.add("&Default");
-        kinds.add("&Spin");
-        kinds.add("Drop do&wn");
         let radio_kind = wx::RadioBox::builder(Some(&self.base))
-            .choices(kinds)
+            .choices(["&Default", "&Spin", "Drop do&wn"].into())
             .major_dimension(1)
             .style(wx::RA_SPECIFY_COLS.into())
             .build();

--- a/samples/widgets/src/dirctrl.rs
+++ b/samples/widgets/src/dirctrl.rs
@@ -221,8 +221,7 @@ impl WidgetsPage for DirCtrlWidgetsPage {
             wx::Object::none(),
         );
 
-        let std_paths = wx::ArrayString::new();
-        for path in [
+        let std_paths = [
             "&none",
             "&config",
             "&data",
@@ -233,9 +232,8 @@ impl WidgetsPage for DirCtrlWidgetsPage {
             "&user config",
             "&user data",
             "&user local data",
-        ] {
-            std_paths.add(path);
-        }
+        ]
+        .into();
 
         // middle pane
         let radio_std_path = wx::RadioBox::builder(Some(&self.base))

--- a/samples/widgets/src/filectrl.rs
+++ b/samples/widgets/src/filectrl.rs
@@ -106,12 +106,9 @@ impl WidgetsPage for FileCtrlWidgetsPage {
         // left pane
         let sizer_left = wx::BoxSizer::new(wx::VERTICAL);
 
-        let mode = wx::ArrayString::new();
-        mode.add("open");
-        mode.add("save");
         let radio_file_ctrl_mode = wx::RadioBox::builder(Some(&self.base))
             .label("wxFileCtrl mode")
-            .choices(mode)
+            .choices(["open", "save"].into())
             .build();
 
         sizer_left.add_window_int(

--- a/samples/widgets/src/filepicker.rs
+++ b/samples/widgets/src/filepicker.rs
@@ -98,12 +98,9 @@ impl WidgetsPage for FilePickerWidgetsPage {
         // left pane
         let boxleft = wx::BoxSizer::new(wx::VERTICAL);
 
-        let mode = wx::ArrayString::new();
-        mode.add("open");
-        mode.add("save");
         let radio_file_picker_mode = wx::RadioBox::builder(Some(&self.base))
             .label("wxFilePicker mode")
-            .choices(mode)
+            .choices(["open", "save"].into())
             .build();
         boxleft.add_window_int(
             Some(&radio_file_picker_mode),

--- a/samples/widgets/src/headerctrl.rs
+++ b/samples/widgets/src/headerctrl.rs
@@ -95,11 +95,7 @@ impl WidgetsPage for HeaderCtrlWidgetsPage {
         // column flags
         let mut col_settings: Vec<ColSetting> = vec![];
         for i in 0..NUMBER_OF_COLUMNS {
-            let col_alignments = wx::ArrayString::new();
-            col_alignments.add("none");
-            col_alignments.add("left");
-            col_alignments.add("centre");
-            col_alignments.add("right");
+            let col_alignments = ["none", "left", "centre", "right"].into();
 
             let sizer_col = wx::StaticBoxSizer::new_with_int(
                 wx::VERTICAL,

--- a/samples/widgets/src/hyperlink.rs
+++ b/samples/widgets/src/hyperlink.rs
@@ -127,14 +127,9 @@ impl WidgetsPage for HyperlinkWidgetsPage {
             wx::Object::none(),
         );
 
-        let alignments = wx::ArrayString::new();
-        alignments.add("&left");
-        alignments.add("&centre");
-        alignments.add("&right");
-
         let radio_align_mode = wx::RadioBox::builder(Some(&self.base))
             .label("alignment")
-            .choices(alignments)
+            .choices(["&left", "&centre", "&right"].into())
             .build();
         radio_align_mode.set_selection(1); // start with "centre" selected since
                                            // wxHL_DEFAULT_STYLE contains wxHL_ALIGN_CENTRE

--- a/samples/widgets/src/listbox.rs
+++ b/samples/widgets/src/listbox.rs
@@ -183,11 +183,7 @@ impl WidgetsPage for ListboxWidgetsPage {
             .build();
         let sizer_left = wx::StaticBoxSizer::new_with_staticbox(Some(&s_box), wx::VERTICAL);
 
-        let modes = wx::ArrayString::new();
-        modes.add("single");
-        modes.add("extended");
-        modes.add("multiple");
-
+        let modes = ["single", "extended", "multiple"].into();
         let radio_sel_mode = wx::RadioBox::builder(Some(&self.base))
             .label("Selection &mode:")
             .choices(modes)
@@ -195,11 +191,7 @@ impl WidgetsPage for ListboxWidgetsPage {
             .style(wx::RA_SPECIFY_COLS.into())
             .build();
 
-        let list_types = wx::ArrayString::new();
-        list_types.add("list box");
-        list_types.add("check list box");
-        list_types.add("rearrange list");
-
+        let list_types = ["list box", "check list box", "rearrange list"].into();
         let radio_list_type = wx::RadioBox::builder(Some(&self.base))
             .label("&List type:")
             .choices(list_types)
@@ -699,10 +691,12 @@ impl ListboxWidgetsPage {
     }
 
     fn on_button_add_several(&self) {
-        let items = wx::ArrayString::new();
-        items.add("First");
-        items.add("another one");
-        items.add("and the last (very very very very very very very very very very long) one");
+        let items: wx::ArrayString = [
+            "First",
+            "another one",
+            "and the last (very very very very very very very very very very long) one",
+        ]
+        .into();
         if let Some(lbox) = self.lbox.borrow().as_ref() {
             lbox.insert_arraystring(&items, 0);
         }

--- a/samples/widgets/src/slider.rs
+++ b/samples/widgets/src/slider.rs
@@ -182,12 +182,7 @@ impl WidgetsPage for SliderWidgetsPage {
         let chk_value_label =
             self.create_check_box_and_add_to_sizer(&sizer_left, "Show &value label", wx::ID_ANY);
 
-        let sides = wx::ArrayString::new();
-        sides.add("default");
-        sides.add("top");
-        sides.add("bottom");
-        sides.add("left");
-        sides.add("right");
+        let sides = ["default", "top", "bottom", "left", "right"].into();
         let radio_sides = wx::RadioBox::builder(Some(&self.base))
             .id(SliderPage::RadioSides.into())
             .label("&Label position")

--- a/samples/widgets/src/spinbutton.rs
+++ b/samples/widgets/src/spinbutton.rs
@@ -158,14 +158,9 @@ impl WidgetsPage for SpinButtonWidgetsPage {
 
         sizer_left.add_int_int(5, 5, 0, wx::GROW | wx::ALL, 5, wx::Object::none()); // spacer
 
-        let halign = wx::ArrayString::new();
-        halign.add("left");
-        halign.add("centre");
-        halign.add("right");
-
         let radio_align = wx::RadioBox::builder(Some(&self.base))
             .label("&Text alignment")
-            .choices(halign)
+            .choices(["left", "centre", "right"].into())
             .major_dimension(1)
             .build();
         sizer_left.add_window_int(

--- a/samples/widgets/src/toggle.rs
+++ b/samples/widgets/src/toggle.rs
@@ -157,14 +157,9 @@ impl WidgetsPage for ToggleWidgetsPage {
 
         sizer_left.add_spacer(10);
 
-        let dirs = wx::ArrayString::new();
-        dirs.add("left");
-        dirs.add("right");
-        dirs.add("top");
-        dirs.add("bottom");
         let radio_image_pos = wx::RadioBox::builder(Some(&self.base))
             .label("Image &position")
-            .choices(dirs)
+            .choices(["left", "right", "top", "bottom"].into())
             .build();
         sizer_left.add_window_sizerflags(
             Some(&radio_image_pos),
@@ -172,22 +167,14 @@ impl WidgetsPage for ToggleWidgetsPage {
         );
         sizer_left.add_spacer(15);
 
-        let halign = wx::ArrayString::new();
-        halign.add("left");
-        halign.add("centre");
-        halign.add("right");
         let radio_halign = wx::RadioBox::builder(Some(&self.base))
             .label("&Horz alignment")
-            .choices(halign)
+            .choices(["left", "centre", "right"].into())
             .build();
 
-        let valign = wx::ArrayString::new();
-        valign.add("top");
-        valign.add("centre");
-        valign.add("bottom");
         let radio_valign = wx::RadioBox::builder(Some(&self.base))
             .label("&Vert alignment")
-            .choices(valign)
+            .choices(["top", "centre", "bottom"].into())
             .build();
 
         sizer_left.add_window_sizerflags(

--- a/wx-base/src/lib.rs
+++ b/wx-base/src/lib.rs
@@ -314,7 +314,7 @@ where
     fn from(items: T) -> Self {
         let array_string = Self::new();
         for item in items {
-            array_string.add(&format!("{item}"));
+            array_string.add(&item.to_string());
         }
         array_string
     }

--- a/wx-base/src/lib.rs
+++ b/wx-base/src/lib.rs
@@ -306,6 +306,20 @@ impl<const OWNED: bool> Drop for ArrayStringIsOwned<OWNED> {
     }
 }
 
+impl<T> From<T> for ArrayString
+where
+    T: IntoIterator,
+    T::Item: std::fmt::Display,
+{
+    fn from(items: T) -> Self {
+        let array_string = Self::new();
+        for item in items {
+            array_string.add(&format!("{item}"));
+        }
+        array_string
+    }
+}
+
 // (wx)String::const_iterator
 wxwidgets! {
     class StringConstIterator


### PR DESCRIPTION
I've added a "From" trait to _wx::ArrayString_ that allows it to be initialized by any type that implements _IntoIterator_ and for any item that implements the _Display_ trait.  This allowed me to clean up a lot of code in the samples.

So, instead of 
```
let x = wx::ArrayString::new()
x.add("1");
x.add("1");
```
you can just do :
`let x = wx::ArrayString::from(["1", "2"]);`

or even better:
`let x = ["1", "2"].into();`
when the compiler can figure out that _x_ is an ArrayString (which happens a lot in the sample code).

You can also do things like:
`wx::RadioBox::builder(Some(&self.base)).choices((1..3).into()).build()`
because integer types implement the _Display_ trait.